### PR TITLE
Removed duplicate ("_repr_html_", "text/html") item

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -628,7 +628,6 @@ def _formatter(data, repr_func):
            ("_repr_jpeg_", "image/jpeg"),
            ("_repr_html_", "text/html"),
            ("_repr_markdown_", "text/markdown"),
-           ("_repr_html_", "text/html"),
            ("_repr_svg_", "image/svg+xml"),
            ("_repr_latex_", "text/latex"),
            ("_repr_json_", "application/json"),


### PR DESCRIPTION
There is a duplicate item ("_repr_html_", "text/html") in the list.
I think it would be better to remove it.