### PR TITLE
Exec in a function having a subfunction requires a context

### DIFF
--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -60,7 +60,7 @@ class PythonMagic(Magic):
         except:
             pass
         try:
-            exec(code.strip(), self.env)
+            exec(code.strip(), self.env) in globals(), locals()
         except Exception as exc:
             self.kernel.Error(traceback.format_exc())
             return None


### PR DESCRIPTION
Issue was encountered/reported on Calisto/matlab_kernel Issue #24[1]
and the resolution proposed fix is described on:
StackOverflow: In Python, why doesn't exec work in a function
with a subfunction?[2]

[1] https://github.com/Calysto/matlab_kernel/issues/24
[2] http://stackoverflow.com/questions/4484872/in-python-why-doesnt-exec-work-in-a-function-with-a-subfunction