### PR TITLE
bug fixed timeout=None

### DIFF
--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -1663,7 +1663,7 @@ class spawn(object):
         Like :meth:`expect`, passing ``async=True`` will make this return an
         asyncio coroutine.
         '''
-        if timeout in [None, -1]:
+        if timeout == -1:
             timeout = self.timeout
 
         exp = Expecter(self, searcher_re(pattern_list), searchwindowsize)
@@ -1687,7 +1687,7 @@ class spawn(object):
         Like :meth:`expect`, passing ``async=True`` will make this return an
         asyncio coroutine.
         '''
-        if timeout in [None,  -1]:
+        if timeout == -1:
             timeout = self.timeout
 
         if (isinstance(pattern_list, self.allowed_string_types) or


### PR DESCRIPTION
timeout=None was overwritten by self.timeout, however timeout=None is a valid timeout value which should be passed forward instead of resetting it

[I recognized this while using the new octave_kernel for jupyter. Out of sudden things broke with a timeout error. Now it works again as expected and I can use the jupyter notebook as normal.]