### PR TITLE
still timeout=None seems to be ignored

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -133,7 +133,7 @@ class REPLWrapper(object):
 
         self.sendline(cmdlines[0])
         for line in cmdlines[1:]:
-            self._expect_prompt(timeout=-1)
+            self._expect_prompt(timeout=timeout)
             text += self.child.before
             self.sendline(line)
 


### PR DESCRIPTION
I am not sure whether this is the right place to adapt, however it gives the desired result and prevents the timeout error message (printed below).
Maybe there are still more of such mistakes surrounding the timeout=-1 default.

```
[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/ipykernel/kernelbase.py", line 212, in dispatch_shell
    handler(stream, idents, msg)
  File "/usr/local/lib/python2.7/dist-packages/ipykernel/kernelbase.py", line 370, in execute_request
    user_expressions, allow_stdin)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/_metakernel.py", line 337, in do_execute
    retval = self.do_execute_direct(code)
  File "/usr/local/lib/python2.7/dist-packages/octave_kernel.py", line 88, in do_execute_direct
    resp = super(OctaveKernel, self).do_execute_direct(code)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/process_metakernel.py", line 61, in do_execute_direct
    output = self.wrapper.run_command(code.rstrip(), timeout=None)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/replwrap.py", line 136, in run_command
    self._expect_prompt(timeout=-1)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/replwrap.py", line 101, in _expect_prompt
    timeout=timeout)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/pexpect.py", line 1649, in expect
    timeout, searchwindowsize, async)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/pexpect.py", line 1670, in expect_list
    return exp.expect_loop(timeout)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/pexpect.py", line 232, in expect_loop
    return self.timeout(e)
  File "/usr/local/lib/python2.7/dist-packages/metakernel/pexpect.py", line 197, in timeout
    raise TIMEOUT(msg)
TIMEOUT: Timeout exceeded.
<metakernel.pexpect.spawnu object at 0x7ff66a3c2d10>
version: 3.3
command: /usr/bin/octave
args: ['/usr/bin/octave']
searcher: None
buffer (last 100 chars): u''
before (last 100 chars): u''
after: <class 'metakernel.pexpect.TIMEOUT'>
match: None
match_index: None
exitstatus: None
flag_eof: False
pid: 9504
child_fd: 47
closed: False
timeout: 30
delimiter: <class 'metakernel.pexpect.EOF'>
logfile: None
logfile_read: None
logfile_send: None
maxread: 2000
ignorecase: False
searchwindowsize: None
delaybeforesend: 0.05
delayafterclose: 0.1
delayafterterminate: 0.1
```