### PR TITLE
fix .encode AttributeError on repr

### DIFF
--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -10,6 +10,10 @@ __version__ = '0.0'
 
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
 
+if PY3:
+    string_types = (str,)
+else:
+    string_types = basestring
 
 class ProcessMetaKernel(MetaKernel):
     implementation = 'process_kernel'
@@ -38,8 +42,19 @@ class ProcessMetaKernel(MetaKernel):
     def __init__(self, **kwargs):
         MetaKernel.__init__(self, **kwargs)
         self.wrapper = None
-        self.repr = str if PY3 else lambda x: x.encode('utf-8')
         self._start()
+    
+    def repr(self, item):
+        """Return text representation
+        
+        Don't wrap str in repr to avoid adding quotes to reprs from subprocesses.
+        """
+        if isinstance(item, string_types):
+            # return the string itself because repr would wrap it in quotes
+            return item
+        else:
+            # use regular repr on non-string objects
+            return repr(item)
 
     def _start(self):
         if not self.wrapper is None:

--- a/metakernel/tests/test_process_metakernel.py
+++ b/metakernel/tests/test_process_metakernel.py
@@ -1,4 +1,6 @@
 
+from IPython.display import HTML
+
 from metakernel.tests.utils import get_kernel, get_log_text
 from metakernel.process_metakernel import BashKernel
 
@@ -17,3 +19,6 @@ def test_process_metakernel():
     kernel.do_execute('lalkjds')
     text = get_log_text(kernel)
     assert ': command not found' in text, text
+    
+    html = HTML("some html")
+    kernel.Display(html)


### PR DESCRIPTION
don't assume that self.repr is exclusively called on unicode text

This isn't perfect, because it does ensure that display of strings will strip quotes even when it shouldn't, but it at least should make it behave as it seems to be meaning to.

closes Calysto/octave_kernel#30