### PR TITLE
wrap output in TextOutput in ProcessMetaKernel

### DIFF
--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from . import MetaKernel
 from .pexpect import EOF
-from .replwrap import REPLWrapper, u, PY3
+from .replwrap import REPLWrapper, u
 from subprocess import check_output
 import os
 import re
@@ -9,6 +9,18 @@ import re
 __version__ = '0.0'
 
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
+
+
+class TextOutput(object):
+    """Wrapper for text output whose repr is the text itself.
+    
+    This avoids `repr(output)` adding quotation marks around already-rendered text.
+    """
+    def __init__(self, output):
+        self.output = output
+    
+    def __repr__(self):
+        return self.output
 
 
 class ProcessMetaKernel(MetaKernel):
@@ -38,7 +50,6 @@ class ProcessMetaKernel(MetaKernel):
     def __init__(self, **kwargs):
         MetaKernel.__init__(self, **kwargs)
         self.wrapper = None
-        self.repr = str if PY3 else lambda x: x.encode('utf-8')
         self._start()
 
     def _start(self):
@@ -91,7 +102,7 @@ class ProcessMetaKernel(MetaKernel):
                             'execution_count': self.execution_count,
                             'payload': [], 'user_expressions': {}}
 
-        return output
+        return TextOutput(output)
 
     def check_exitcode(self):
         """

--- a/metakernel/tests/test_process_metakernel.py
+++ b/metakernel/tests/test_process_metakernel.py
@@ -1,4 +1,6 @@
 
+from IPython.display import HTML
+
 from metakernel.tests.utils import get_kernel, get_log_text
 from metakernel.process_metakernel import BashKernel
 
@@ -17,3 +19,6 @@ def test_process_metakernel():
     kernel.do_execute('lalkjds')
     text = get_log_text(kernel)
     assert ': command not found' in text, text
+    
+    html = HTML("some html")
+    kernel.Display(html)


### PR DESCRIPTION
removes the need for special `repr` method on this class, instead using a class designating text output that shouldn't get quotes added to it.

potential alternative to #87
closes Calysto/octave_kernel#30