### PR TITLE
Fix kernelspec install.

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -91,7 +91,7 @@ class MetaKernel(Kernel):
             if __name__ == '__main__':
                 MetaKernelSubclass.run_as_main()
         """
-        _MetaKernelApp.launch_instance(kernel_class=cls)
+        MetaKernelApp.launch_instance(kernel_class=cls)
 
     def __init__(self, *args, **kwargs):
         super(MetaKernel, self).__init__(*args, **kwargs)
@@ -657,7 +657,7 @@ class MetaKernel(Kernel):
         return retval
 
 
-class _MetaKernelApp(IPKernelApp):
+class MetaKernelApp(IPKernelApp):
 
     @property
     def subcommands(self):


### PR DESCRIPTION
Sorry I broke everything...

While the previous implementation improved kernelspec installation, it
actually did not actually allow starting one.  This is because traitlets
assumes that class names start with an uppercase letter, so
`_MetaKernelApp` must be renamed to `MetaKernelApp`.  Fortunately it
still remains private as it is only defined in `metakernel._metakernel`.

(See https://github.com/ipython/ipython/pull/4276#issuecomment-26621822)