### PR TITLE
Save history as JSON, to handle multiline entries.

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -389,28 +389,17 @@ class MetaKernel(Kernel):
         """
         Access history at startup.
         """
-        if not self.hist_file:
-            return {'history': []}
-        # else:
-        if not os.path.exists(self.hist_file):
-            with open(self.hist_file, 'wb') as fid:
-                fid.write('')
-        with open(self.hist_file, 'rb') as fid:
-            history = fid.read().decode('utf-8', 'replace')
-        history = history.splitlines()
-        history = history[:self.max_hist_cache]
-        self.hist_cache = history
-        history = [(None, None, h) for h in history]
-        return {'history': history}
+        with open(self.hist_file) as fid:
+            self.hist_cache = json.loads(fid.read() or "[]")
+        return {'history': [(None, None, h) for h in self.hist_cache]}
 
     def do_shutdown(self, restart):
         """
         Shut down the app gracefully, saving history.
         """
         if self.hist_file:
-            with open(self.hist_file, 'wb') as fid:
-                data = '\n'.join(self.hist_cache[-self.max_hist_cache:])
-                fid.write(data.encode('utf-8'))
+            with open(self.hist_file, "w") as fid:
+                json.dump(self.hist_cache[-self.max_hist_cache:], fid)
         if restart:
             self.Print("Restarting kernel...")
             self.reload_magics()

--- a/metakernel/config.py
+++ b/metakernel/config.py
@@ -13,16 +13,15 @@ def get_history_file(kernel):
     base = get_ipython_dir()
     dname = os.path.join(base, 'metakernel', 'history')
     if not os.path.exists(dname):
-            os.makedirs(dname)
+        os.makedirs(dname)
     if hasattr(kernel, 'implementation'):
         fname = kernel.implementation.lower()
     else:
         fname = kernel.__class__.__name__
         fname = fname.replace("Magic", '').lower()
-    path = os.path.join(dname, fname + '.txt')
-    if not os.path.exists(path):
-        with open(path, 'wb'):
-            pass
+    path = os.path.join(dname, fname + '.json')
+    with open(path, 'a'):
+        pass
     return path
 
 


### PR DESCRIPTION
See #103.