### PR TITLE
Remove workaround

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -118,8 +118,6 @@ class MetaKernel(Kernel):
                 sys.stdout.write = self.Write
             except:
                 pass  # Can't change stdout
-        # This is for ipykernel.comm.manager:
-        self.log.DEBUG = False
         self.sticky_magics = {}
         self._i = None
         self._ii = None


### PR DESCRIPTION
This line was added to workaround this bug:

https://github.com/ipython/ipykernel/pull/185/files#diff-cf792864a29c5f1f583e02552983ac09R70

Can now be removed.