### PR TITLE
Clean up plot magic handling and add width/height options

### DIFF
--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -165,7 +165,7 @@ def _parse_args(func, args, usage=None):
 
     kwargs = dict()
     if getattr(func, 'has_options', False):
-        parser = MagicOptionParser(usage=usage)
+        parser = MagicOptionParser(usage=usage, conflict_handler="resolve")
         parser.add_options(func.options)
 
         left = []

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -19,15 +19,15 @@ class PlotMagic(Magic):
         help='Backend selection'
     )
     @option(
-        '-r', '--resolution', type='int', action='store',
+        '-r', '--resolution', action='store',
         help='Resolution in pixels per inch'
     )
     @option(
-        '-w', '--width', type='int', action='store',
+        '-w', '--width', action='store',
         help='Plot width in pixels'
     )
     @option(
-        '-h', '--height', type='int', action='store',
+        '-h', '--height', action='store',
         help='Plot height in pixels'
     )
     def line_plot(self, *args, **kwargs):

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -11,7 +11,7 @@ class PlotMagic(Magic):
         help='Pixel size of plots, "width,height"'
     )
     @option(
-        '-f', '--format', action='store', default='png',
+        '-f', '--format', action='store',
         help='Plot format (png, svg or jpg).'
     )
     @option(
@@ -19,8 +19,16 @@ class PlotMagic(Magic):
         help='Backend selection'
     )
     @option(
-        '-r', '--resolution', action='store', default=96,
+        '-r', '--resolution', type='int', action='store',
         help='Resolution in pixels per inch'
+    )
+    @option(
+        '-w', '--width', type='int', action='store',
+        help='Plot width in pixels'
+    )
+    @option(
+        '-h', '--height', type='int', action='store',
+        help='Plot height in pixels'
     )
     def line_plot(self, *args, **kwargs):
         """
@@ -31,14 +39,18 @@ class PlotMagic(Magic):
 
         Examples:
             %plot qt --format=png
-            %plot inline -s 640,480
+            %plot inline -w 640
 
         Note: not all languages may support the %plot magic, and not all
         options may be supported.
         """
         if args and not args[0].startswith('-'):
             kwargs['backend'] = args[0]
-        self.kernel.plot_settings.update(**kwargs)
+        if kwargs['size']:
+            width, height = kwargs['size']
+            kwargs['width'] = int(width)
+            kwargs['height'] = int(height)
+        self.kernel.plot_settings = kwargs
         self.kernel.handle_plot_settings()
 
 

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -50,6 +50,10 @@ class PlotMagic(Magic):
             width, height = kwargs['size']
             kwargs['width'] = int(width)
             kwargs['height'] = int(height)
+        # Remove empty options so ".setdefault" will work.
+        for key in ['resolution', 'format', 'size', 'width', 'height']:
+            if kwargs[key] is None:
+                del kwargs[key]
         self.kernel.plot_settings = kwargs
         self.kernel.handle_plot_settings()
 

--- a/metakernel/magics/tests/test_plot_magic.py
+++ b/metakernel/magics/tests/test_plot_magic.py
@@ -5,26 +5,32 @@ from metakernel.tests.utils import get_kernel
 def test_plot_magic_backend():
     kernel = get_kernel()
     kernel.do_execute('%plot qt -f svg -s400,200', None)
-    assert kernel.plot_settings['size'] == (400, 200)
+    assert kernel.plot_settings['width'] == 400
+    assert kernel.plot_settings['height'] == 200
     assert kernel.plot_settings['format'] == 'svg'
     assert kernel.plot_settings['backend'] == 'qt'
 
 def test_plot_magic_format():
     kernel = get_kernel()
-    kernel.do_execute('%plot qt -f svg')
+    kernel.do_execute('%plot qt -f svg -w 500 -h 400 -r 200')
     assert kernel.plot_settings['backend'] == 'qt', kernel.plot_settings
     assert kernel.plot_settings['format'] == 'svg', kernel.plot_settings
+    assert kernel.plot_settings['width'] == 500, kernel.plot_settings
+    assert kernel.plot_settings['height'] == 400, kernel.plot_settings
+    assert kernel.plot_settings['resolution'] == 200, kernel.plot_settings
 
 def test_plot_magic_size():
     kernel = get_kernel()
     kernel.do_execute('%plot qt4 -s 400,200')
-    assert kernel.plot_settings['size'] == (400, 200), kernel.plot_settings
+    assert kernel.plot_settings['width'] == 400
+    assert kernel.plot_settings['height'] == 200
     assert kernel.plot_settings['backend'] == 'qt4', kernel.plot_settings
 
 def test_plot_magic_all():
     kernel = get_kernel()
     kernel.do_execute('%plot -b qt5 -f svg -s 400,200')
-    assert kernel.plot_settings['size'] == (400, 200), kernel.plot_settings
+    assert kernel.plot_settings['width'] == 400
+    assert kernel.plot_settings['height'] == 200
     assert kernel.plot_settings['format'] == 'svg', kernel.plot_settings
     assert kernel.plot_settings['backend'] == 'qt5', kernel.plot_settings
 


### PR DESCRIPTION
This changes the semantics somewhat for kernel authors in that the existing settings are replaced instead of updated and no default settings are applied other than backend.  However, this is more in line with what the user has requested. 

Fixes #102.