### PR TITLE
Add support for stdin requests and clean up replwrap

### DIFF
--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -57,10 +57,8 @@ class ProcessMetaKernel(MetaKernel):
             self.wrapper.child.terminate()
         self.wrapper = self.makeWrapper()
 
-    def do_execute_direct(self, code, stream_handler=None):
+    def do_execute_direct(self, code, silent=False):
         """Execute the code in the subprocess.
-        Use the stream_handler to process lines as they are emitted
-        by the subprocess.
         """
         self.payload = []
 
@@ -75,12 +73,11 @@ class ProcessMetaKernel(MetaKernel):
 
         interrupted = False
         output = ''
+        stream_handler = self.Print if not silent else None
         try:
             output = self.wrapper.run_command(code.rstrip(), timeout=None,
                                      stream_handler=stream_handler,
                                      stdin_handler=self.raw_input)
-            if stream_handler is not None:
-                output = ''
         except KeyboardInterrupt as e:
             interrupted = True
             output = self.wrapper.child.before

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -10,6 +10,18 @@ __version__ = '0.0'
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
 
 
+class TextOutput(object):
+    """Wrapper for text output whose repr is the text itself.
+
+    This avoids `repr(output)` adding quotation marks around already-rendered text.
+    """
+    def __init__(self, output):
+        self.output = output
+
+    def __repr__(self):
+        return self.output
+
+
 class ProcessMetaKernel(MetaKernel):
     implementation = 'process_kernel'
     implementation_version = __version__
@@ -96,6 +108,9 @@ class ProcessMetaKernel(MetaKernel):
                 'payload': [],
                 'user_expressions': {},
             }
+
+        if silent and output:
+            return TextOutput(output)
 
     def check_exitcode(self):
         """

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -3,24 +3,11 @@ from . import MetaKernel
 from pexpect import EOF
 from .replwrap import REPLWrapper, bash
 from subprocess import check_output
-import os
 import re
 
 __version__ = '0.0'
 
 version_pat = re.compile(r'version (\d+(\.\d+)+)')
-
-
-class TextOutput(object):
-    """Wrapper for text output whose repr is the text itself.
-
-    This avoids `repr(output)` adding quotation marks around already-rendered text.
-    """
-    def __init__(self, output):
-        self.output = output
-
-    def __repr__(self):
-        return self.output
 
 
 class ProcessMetaKernel(MetaKernel):
@@ -109,8 +96,6 @@ class ProcessMetaKernel(MetaKernel):
                 'payload': [],
                 'user_expressions': {},
             }
-
-        return TextOutput(output)
 
     def check_exitcode(self):
         """

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -53,7 +53,7 @@ class ProcessMetaKernel(MetaKernel):
         self._start()
 
     def _start(self):
-        if not self.wrapper is None:
+        if self.wrapper is not None:
             self.wrapper.child.terminate()
         self.wrapper = self.makeWrapper()
 
@@ -77,7 +77,8 @@ class ProcessMetaKernel(MetaKernel):
         output = ''
         try:
             output = self.wrapper.run_command(code.rstrip(), timeout=None,
-                                     stream_handler=stream_handler)
+                                     stream_handler=stream_handler,
+                                     stdin_handler=self.raw_input)
             if stream_handler is not None:
                 output = ''
         except KeyboardInterrupt as e:
@@ -159,12 +160,14 @@ class DynamicKernel(ProcessMetaKernel):
                  orig_prompt=None,
                  prompt_change=None,
                  prompt_cmd=None,
-                 extra_init_cmd=None):
+                 extra_init_cmd=None,
+                 stdin_prompt_regex=None):
         self.executable = executable
         self.orig_prompt = orig_prompt
         self.prompt_change = prompt_change
         self.prompt_cmd = prompt_cmd
         self.extra_init_cmd = extra_init_cmd
+        self.stdin_prompt_regex = stdin_prompt_regex
         self.implementation = implementation
         self.language = language
         self.language_info['mimetype'] = mimetype
@@ -177,6 +180,7 @@ class DynamicKernel(ProcessMetaKernel):
                            self.orig_prompt,
                            self.prompt_change,
                            prompt_cmd=self.prompt_cmd,
+                           stdin_prompt_regex=self.stdin_prompt_regex,
                            extra_init_cmd=self.extra_init_cmd)
 
     """

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -123,7 +123,7 @@ class REPLWrapper(object):
 
     def _expect_inner(self, expects, timeout):
         try:
-            return self.child.expect_exact(expects, timeout=timeout)
+            return self.child.expect(expects, timeout=timeout)
         except KeyboardInterrupt:
             self.child.kill(signal.SIGINT)
             if self.prompt_emit_cmd:

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -125,7 +125,7 @@ class REPLWrapper(object):
         try:
             return self.child.expect_exact(expects, timeout=timeout)
         except KeyboardInterrupt:
-            self.child.sendintr()
+            self.child.kill(signal.SIGINT)
             if self.prompt_emit_cmd:
                 time.sleep(1.)
             try:

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -113,7 +113,7 @@ class REPLWrapper(object):
                 line = stdin_handler(self.child.after)
                 self.sendline(line)
             elif pos == 3:  # End of line received
-                stream_handler(self.child.before + '\n')
+                stream_handler(self.child.before)
             else:
                 if len(self.child.before) != 0 and stream_handler:
                     # prompt received, but partial line precedes it

--- a/metakernel/tests/test_replwrap.py
+++ b/metakernel/tests/test_replwrap.py
@@ -66,18 +66,6 @@ class REPLWrapTestCase(unittest.TestCase):
         res = p.run_command('for a in range(3): print(a)\n')
         assert res.strip().splitlines() == ['0', '1', '2']
 
-    def test_no_change_prompt(self):
-        if platform.python_implementation() == 'PyPy':
-            raise unittest.SkipTest("This test fails on PyPy because of REPL differences")
-
-        child = pexpect.spawnu('python', echo=False, timeout=5)
-        # prompt_change=None should mean no prompt change
-        py = replwrap.REPLWrapper(child, replwrap.u(">>> "), prompt_change_cmd=None, continuation_prompt_regex=replwrap.u(re.escape("... ")))
-        assert py.prompt_regex == ">>> "
-
-        res = py.run_command("for a in range(3): print(a)\n")
-        assert res.strip().splitlines() == ['0', '1', '2']
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Tested using the `keyboard` command in Octave:

<img width="551" alt="screen shot 2016-12-20 at 4 58 49 pm" src="https://cloud.githubusercontent.com/assets/2096628/21371208/9b1571ea-c6d5-11e6-8af7-6687009204d2.png">
