### PR TITLE
Added support for better error handling to metakernel

### DIFF
--- a/metakernel/__init__.py
+++ b/metakernel/__init__.py
@@ -1,5 +1,5 @@
 from ._metakernel import (
-    MetaKernel, IPythonKernel, register_ipython_magics, get_metakernel)
+    ExceptionWrapper, MetaKernel, IPythonKernel, register_ipython_magics, get_metakernel)
 from . import pexpect
 from .replwrap import REPLWrapper, u
 from .process_metakernel import ProcessMetaKernel

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -67,9 +67,12 @@ class ExceptionWrapper(object):
     """
 
     def __init__(self, ename, evalue, traceback):
-        self.evalue = evalue
         self.ename = ename
+        self.evalue = evalue
         self.traceback = traceback
+
+    def __repr__(self):
+        return '{}: {}\n{}'.format(self.ename, self.evalue, self.traceback)
 
 
 def lazy_import_handle_comm_opened(*args, **kwargs):

--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -19,7 +19,8 @@ def exec_code(code, env, kernel):
         exec(code, env) 
     except Exception as exc:
         import traceback
-        return ExceptionWrapper(exc.__class__.__name__, exc.args, traceback.format_tb(exc.__traceback__))
+        ex_type, ex, tb = sys.exc_info()
+        return ExceptionWrapper(ex_type.__name__, repr(exc.args), traceback.format_tb(tb))
     if "retval" in env:
         return env["retval"]
 

--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic, option
+from metakernel import Magic, option, ExceptionWrapper
 import traceback
 import sys
 try:
@@ -18,8 +18,8 @@ def exec_code(code, env, kernel):
     try:
         exec(code, env) 
     except Exception as exc:
-        kernel.Error(traceback.format_exc())
-        return None
+        import traceback
+        return ExceptionWrapper(exc.__class__.__name__, exc.args, traceback.format_tb(exc.__traceback__))
     if "retval" in env:
         return env["retval"]
 

--- a/metakernel/magics/tests/test_python_magic.py
+++ b/metakernel/magics/tests/test_python_magic.py
@@ -1,3 +1,4 @@
+import textwrap
 
 from metakernel.tests.utils import get_kernel, get_log_text, clear_log_text
 
@@ -19,10 +20,11 @@ def test_python_magic2():
     kernel.do_execute('%python retval = 1', None)
     assert '1' in get_log_text(kernel)
 
-    kernel.do_execute('''%%python
-        def test(a):
-            return a + 1
-        retval = test(2)''', None)
+    kernel.do_execute(textwrap.dedent('''\
+    %%python
+    def test(a):
+        return a + 1
+    retval = test(2)'''), None)
     assert '3' in get_log_text(kernel)
 
 


### PR DESCRIPTION
This is a rough draft for being able to better support ipython style exception handling instead of just printing to stderr. 

This will also allow us to make tools like nbconvert happier since we can actually fail now -- previously all messages would always be of status 'ok'.

Let me know if you want anything else in here.  

I'm currently working on a scala metakernal in https://github.com/mariusvniekerk/spylon-kernel

