### PR TITLE
Update versions of MetaKernel kernels.

### DIFF
--- a/metakernel_bash/setup.py
+++ b/metakernel_bash/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='metakernel_bash',
-      version='0.11.3',
+      version='0.19.1',
       description='A Bash kernel for Jupyter/IPython',
       long_description='A Bash kernel for Jupyter/IPython, based on MetaKernel',
       url='https://github.com/calysto/metakernel/tree/master/metakernel_bash',

--- a/metakernel_echo/setup.py
+++ b/metakernel_echo/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='metakernel_echo',
-      version='0.11.3',
+      version='0.19.1',
       description='A simple echo kernel for Jupyter/IPython',
       long_description='A simple echo kernel for Jupyter/IPython, based on MetaKernel',
       url='https://github.com/calysto/metakernel/tree/master/metakernel_echo',

--- a/metakernel_python/setup.py
+++ b/metakernel_python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='metakernel_python',
-      version='0.11.3',
+      version='0.19.1',
       description='A Python kernel for Jupyter/IPython',
       long_description='A Python kernel for Jupyter/IPython, based on MetaKernel',
       url='https://github.com/calysto/metakernel/tree/master/metakernel_python',


### PR DESCRIPTION
This just resyncs them with the main `metakernel` package. I'm fairly certain these have all been changed since 0.11.3 at least a little bit.