### PR TITLE
Restore Jedi 0.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 
 language: python
-python:
-    - 2.7
-    - 3.4
-    - 3.5
+env:
+  global:
+    - JEDI="jedi"
+matrix:
+  include:
+    - python: 2.7
+      env: JEDI="jedi==0.9"
+    - python: 3.4
+    - python: 3.5
 
 
 install:
-    - travis_retry pip install coveralls jedi ipyparallel
+    - travis_retry pip install coveralls ipyparallel $JEDI
     - travis_retry python setup.py install
     - cd metakernel_python
     - python setup.py install


### PR DESCRIPTION
This is sort-of a revert of #129, or a bit of a remix. It should fix #136.

Both Fedora and Ubuntu seem to be on 0.9, so I think it makes sense to keep compatibility rather than bumping the requirements.