### PR TITLE
Mark tests that use the network

### DIFF
--- a/metakernel/magics/tests/test_download_magic.py
+++ b/metakernel/magics/tests/test_download_magic.py
@@ -2,7 +2,10 @@
 from metakernel.tests.utils import (get_kernel, get_log_text, 
                                     clear_log_text, EvalKernel)
 import os
+from nose.plugins.attrib import attr
 
+
+@attr('network')
 def test_download_magic():
     kernel = get_kernel(EvalKernel)
     kernel.do_execute("%download --filename TEST.txt https://raw.githubusercontent.com/calysto/metakernel/master/LICENSE.txt")

--- a/metakernel/magics/tests/test_install_magic_magic.py
+++ b/metakernel/magics/tests/test_install_magic_magic.py
@@ -14,5 +14,9 @@ def test_install_magic_magic():
     assert re.match(".*Downloaded '.*ipython/metakernel/magics/cd_magic.py'", text, re.DOTALL | re.M), "Not downloaded"
     assert os.path.isfile(filename), ("File not found: %s" % filename)
 
+
 def teardown():
-    os.remove(filename)
+    try:
+        os.remove(filename)
+    except OSError:
+        pass

--- a/metakernel/magics/tests/test_install_magic_magic.py
+++ b/metakernel/magics/tests/test_install_magic_magic.py
@@ -4,9 +4,13 @@ from metakernel.tests.utils import (get_kernel, get_log_text,
 import re
 import os
 from metakernel.config import get_local_magics_dir
+from nose.plugins.attrib import attr
+
 
 filename = get_local_magics_dir() + os.sep + "cd_magic.py"
 
+
+@attr('network')
 def test_install_magic_magic():
     kernel = get_kernel(EvalKernel)
     kernel.do_execute("%install_magic https://raw.githubusercontent.com/calysto/metakernel/master/metakernel/magics/cd_magic.py")

--- a/metakernel/magics/tests/test_jigsaw_magic.py
+++ b/metakernel/magics/tests/test_jigsaw_magic.py
@@ -2,7 +2,10 @@
 from metakernel.tests.utils import (get_kernel, get_log_text, 
                                     clear_log_text, EvalKernel)
 import os
+from nose.plugins.attrib import attr
 
+
+@attr('network')
 def test_jigsaw_magic():
     kernel = get_kernel(EvalKernel)
     kernel.do_execute("%jigsaw Processing --workspace workspace1")


### PR DESCRIPTION
This enables builders on network-constrained systems to avoid those tests.

Also fix an error in the tear down of `test_install_magic_magic` if it fails.