### PR TITLE
replwrap module requires path to *real* pexpect path to find bashrc.sh

### DIFF
--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 import os
 import signal
-from pexpect import is_executable_file, EOF, TIMEOUT
+from pexpect import is_executable_file, EOF, TIMEOUT, __file__
 
 try:
     from pexpect import spawn as pty_spawn


### PR DESCRIPTION
This merge redefines `__file__` to point to the *real* pexpect module path, such that the following statement works as expected:
https://github.com/Calysto/metakernel/blob/c4eddf117bd4d1a2ad22ea45a9238693e3859c50/metakernel/replwrap.py#L232

I do not like this solution, but it did resolve the problems on my CentOS 7 workstation.
