### PR TITLE
Get kernel images from package if possible

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -706,9 +706,14 @@ class MetaKernelApp(IPKernelApp):
                     with open(os.path.join(dirname, 'kernel.json'), 'w') as f:
                         json.dump(kernel_spec, f, sort_keys=True)
                     filenames = ['logo-64x64.png', 'logo-32x32.png']
+                    name = self.kernel_class.__module__
                     for filename in filenames:
-                        data = pkgutil.get_data(__name__.split('.')[0],
-                                                'images/' + filename)
+                        try:
+                            data = pkgutil.get_data(name.split('.')[0],
+                                                    'images/' + filename)
+                        except OSError:
+                            data = pkgutil.get_data('metakernel',
+                                'images/' + filename)
                         with open(os.path.join(dirname, filename), 'wb') as f:
                             f.write(data)
                     try:


### PR DESCRIPTION
I was attempting to add images to the Octave kernel and prior to this change the metakernel images were getting picked up because `__name__` was `metakernel._metakernel` in this context.   Also verified with https://github.com/Calysto/calysto_prolog that this change makes it pick up the correct images.