### PR TITLE
Fix handling of fallback images

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -711,7 +711,7 @@ class MetaKernelApp(IPKernelApp):
                         try:
                             data = pkgutil.get_data(name.split('.')[0],
                                                     'images/' + filename)
-                        except OSError:
+                        except (OSError, IOError):
                             data = pkgutil.get_data('metakernel',
                                 'images/' + filename)
                         with open(os.path.join(dirname, filename), 'wb') as f:

--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -4,14 +4,16 @@
 from distutils.version import LooseVersion
 from metakernel import Magic, option, ExceptionWrapper
 import pydoc
-import traceback
 import sys
 try:
     import jedi
     from jedi import Interpreter
-    if jedi.__version__ >= LooseVersion('0.10.0'):
+    if jedi.__version__ >= LooseVersion('0.11.0'):
         from jedi.api.helpers import get_on_completion_name
-        from jedi import common
+        from parso import split_lines
+    elif jedi.__version__ >= LooseVersion('0.10.0'):
+        from jedi.api.helpers import get_on_completion_name
+        from jedi.common import splitlines as split_lines
     else:
         from jedi.api.helpers import completion_parts
         from jedi.parser.user_context import UserContext
@@ -155,7 +157,7 @@ class PythonMagic(Magic):
         interpreter = Interpreter(text, [self.env])
 
         if jedi.__version__ >= LooseVersion('0.10.0'):
-            lines = common.splitlines(text)
+            lines = split_lines(text)
             name = get_on_completion_name(
                 interpreter._get_module_node(),
                 lines,


### PR DESCRIPTION
We are getting `IOError` in Ubuntu instead of `OSError`.  cf https://github.com/Calysto/matlab_kernel/issues/102