### PR TITLE
Allow a list to be passed as the command

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -59,7 +59,7 @@ class REPLWrapper(object):
                  extra_init_cmd=None,
                  prompt_emit_cmd=None,
                  echo=False):
-        if isinstance(cmd_or_spawn, str):
+        if isinstance(cmd_or_spawn, (str, list)):
             self.child = pexpect.spawnu(cmd_or_spawn, echo=echo,
                                         codec_errors="ignore",
                                         encoding="utf-8")


### PR DESCRIPTION
This is related to https://github.com/Calysto/scilab_kernel/issues/3#issuecomment-338438696.  We need to pass a list because `shlex.split` doesn't work with Windows paths.