### PR TITLE
Replwrap fixes

### DIFF
--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -24,8 +24,7 @@ def spawn(command, args=[], timeout=30, maxread=2000,
     '''
     codec_errors = kwargs.get('codec_errors', kwargs.get('errors', 'strict'))
     if pty is None:
-        if not isinstance(command, (list, tuple)):
-            command = shlex.split(command, posix=False)
+        command = shlex.split(command, posix=os.name == 'posix')
         command += args
         child = PopenSpawn(command, timeout=timeout, maxread=maxread,
                            searchwindowsize=searchwindowsize,

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -34,6 +34,7 @@ class REPLWrapper(object):
     :param cmd_or_spawn: This can either be an instance of
     :class:`pexpect.spawn` in which a REPL has already been started,
     or a str command to start a new REPL process.
+    :param str args: The arguments to pass to the command
     :param str prompt_regex:  Regular expression representing process prompt, eg ">>>" in Python.
     :param str continuation_prompt_regex: Regular expression repesenting process continuation prompt, e.g. "..." in Python.
     :param str prompt_change_cmd: Optional kernel command that sets continuation-of-line-prompts, eg PS1 and PS2, such as "..." in Python.
@@ -59,9 +60,9 @@ class REPLWrapper(object):
                  stdin_prompt_regex=PEXPECT_STDIN_PROMPT,
                  extra_init_cmd=None,
                  prompt_emit_cmd=None,
-                 echo=False):
+                 echo=False, args=[]):
         if isinstance(cmd_or_spawn, basestring):
-            self.child = pexpect.spawnu(cmd_or_spawn, echo=echo,
+            self.child = pexpect.spawnu(cmd_or_spawn, args=args, echo=echo,
                                         codec_errors="ignore",
                                         encoding="utf-8")
         else:
@@ -95,7 +96,6 @@ class REPLWrapper(object):
 
         self._stream_handler = None
         self._stdin_handler = None
-
         self._expect_prompt()
 
         if extra_init_cmd is not None:

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -95,6 +95,7 @@ class REPLWrapper(object):
 
         self._stream_handler = None
         self._stdin_handler = None
+
         self._expect_prompt()
 
         if extra_init_cmd is not None:
@@ -120,6 +121,8 @@ class REPLWrapper(object):
                    self.stdin_prompt_regex]
         if stream_handler:
             expects += [u(self.child.crlf)]
+        if self.prompt_emit_cmd:
+            self.sendline(self.prompt_emit_cmd)
         while True:
             pos = self.child.expect(expects, timeout=timeout)
             if pos == 2 and stdin_handler:
@@ -163,9 +166,6 @@ class REPLWrapper(object):
                 self._expect_prompt(timeout=timeout)
                 res.append(self.child.before)
             self.sendline(line)
-
-        if self.prompt_emit_cmd:
-            self.sendline(prompt_emit_cmd)
 
         # Command was fully submitted, now wait for the next prompt
         if self._expect_prompt(timeout=timeout) == 1:

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -34,7 +34,6 @@ class REPLWrapper(object):
     :param cmd_or_spawn: This can either be an instance of
     :class:`pexpect.spawn` in which a REPL has already been started,
     or a str command to start a new REPL process.
-    :param str args: The arguments to pass to the command
     :param str prompt_regex:  Regular expression representing process prompt, eg ">>>" in Python.
     :param str continuation_prompt_regex: Regular expression repesenting process continuation prompt, e.g. "..." in Python.
     :param str prompt_change_cmd: Optional kernel command that sets continuation-of-line-prompts, eg PS1 and PS2, such as "..." in Python.
@@ -60,9 +59,9 @@ class REPLWrapper(object):
                  stdin_prompt_regex=PEXPECT_STDIN_PROMPT,
                  extra_init_cmd=None,
                  prompt_emit_cmd=None,
-                 echo=False, args=[]):
+                 echo=False):
         if isinstance(cmd_or_spawn, basestring):
-            self.child = pexpect.spawnu(cmd_or_spawn, args=args, echo=echo,
+            self.child = pexpect.spawnu(cmd_or_spawn, echo=echo,
                                         codec_errors="ignore",
                                         encoding="utf-8")
         else:
@@ -96,6 +95,7 @@ class REPLWrapper(object):
 
         self._stream_handler = None
         self._stdin_handler = None
+
         self._expect_prompt()
 
         if extra_init_cmd is not None:


### PR DESCRIPTION
- Only accept strings for commands, and no args
- Only send one line at a time for a command if there is no command emit prompt