### PR TITLE
Use sys.executable when creating kernel.json

### DIFF
--- a/metakernel_bash/metakernel_bash.py
+++ b/metakernel_bash/metakernel_bash.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from metakernel import MetaKernel
+import sys
 
 
 class MetaKernelBash(MetaKernel):
@@ -24,7 +25,7 @@ class MetaKernelBash(MetaKernel):
     }
     kernel_json = {
         'argv': [
-            'python', '-m', 'metakernel_bash', '-f', '{connection_file}'],
+            sys.executable, '-m', 'metakernel_bash', '-f', '{connection_file}'],
         'display_name': 'MetaKernel Bash',
         'language': 'bash',
         'name': 'metakernel_bash'

--- a/metakernel_echo/metakernel_echo.py
+++ b/metakernel_echo/metakernel_echo.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from metakernel import MetaKernel
+import sys
 
 
 class MetaKernelEcho(MetaKernel):
@@ -24,7 +25,7 @@ class MetaKernelEcho(MetaKernel):
     }
     kernel_json = {
         'argv': [
-            'python', '-m', 'metakernel_echo', '-f', '{connection_file}'],
+            sys.executable, '-m', 'metakernel_echo', '-f', '{connection_file}'],
         'display_name': 'MetaKernel Echo',
         'language': 'echo',
         'name': 'metakernel_echo'


### PR DESCRIPTION
Use sys.executable when creating kernel.json for echo and bash. This is already the case for python.
