### PR TITLE
Don't rely on 'python' in path during testing

### DIFF
--- a/metakernel/tests/test_replwrap.py
+++ b/metakernel/tests/test_replwrap.py
@@ -2,6 +2,7 @@ import platform
 import unittest
 import re
 import os
+import sys
 
 from metakernel import pexpect, replwrap
 
@@ -59,7 +60,7 @@ class REPLWrapTestCase(unittest.TestCase):
         if platform.python_implementation() == 'PyPy':
             raise unittest.SkipTest("This test fails on PyPy because of REPL differences")
 
-        p = replwrap.python()
+        p = replwrap.python(sys.executable)
         res = p.run_command('4+7')
         assert res.strip() == '11'
 


### PR DESCRIPTION
The test_python test relies on finding an executable called "python" in the path. The symlink from python to python2 is not guaranteed to exist. And when it is not present the test fails as follows:
````
test_python (metakernel.tests.test_replwrap.REPLWrapTestCase) ... ERROR
======================================================================
ERROR: test_python (metakernel.tests.test_replwrap.REPLWrapTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/metakernel-0.20.14/metakernel/tests/test_replwrap.py", line 62, in test_python
    p = replwrap.python()
  File "/builddir/build/BUILD/metakernel-0.20.14/metakernel/replwrap.py", line 214, in python
    u("import sys; sys.ps1={0!r}; sys.ps2={1!r}"))
  File "/builddir/build/BUILD/metakernel-0.20.14/metakernel/replwrap.py", line 66, in __init__
    encoding="utf-8")
  File "/builddir/build/BUILD/metakernel-0.20.14/metakernel/pexpect.py", line 49, in spawn
    encoding=encoding, codec_errors=codec_errors)
  File "/usr/lib/python2.7/site-packages/pexpect/pty_spawn.py", line 204, in __init__
    self._spawn(command, args, preexec_fn, dimensions)
  File "/usr/lib/python2.7/site-packages/pexpect/pty_spawn.py", line 276, in _spawn
    'executable: %s.' % self.command)
ExceptionPexpect: The command was not found or was not executable: python.
----------------------------------------------------------------------
Ran 77 tests in 33.071s
FAILED (errors=1)
````
This PR changes the test to explicitly request sys.python (i.e. the python version used to run the test - and therefore know to be present) instead of relying on the default value "python". With this change the test succeeds also when the python symlink is not in the path.
