### PR TITLE
Allow to redefine default MetaKernel magics with custom ones

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -576,13 +576,13 @@ class MetaKernel(Kernel):
         # Make a metakernel/magics if it doesn't exist:
         local_magics_dir = get_local_magics_dir()
         # Search all of the places there could be magics:
-        paths = [local_magics_dir,
-                 os.path.join(os.path.dirname(os.path.abspath(__file__)), "magics")]
         try:
-            paths += [os.path.join(os.path.dirname(
+            paths = [os.path.join(os.path.dirname(
                 os.path.abspath(inspect.getfile(self.__class__))), "magics")]
         except:
-            pass
+            paths = []
+        paths += [local_magics_dir,
+                  os.path.join(os.path.dirname(os.path.abspath(__file__)), "magics")]
         for magic_dir in paths:
             sys.path.append(magic_dir)
             magic_files.extend(glob.glob(os.path.join(magic_dir, "*.py")))

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -12,6 +12,7 @@ except:
     # python3
     _maxsize = sys.maxsize
 
+
 class MagicOptionParser(optparse.OptionParser):
     def error(self, msg):
         raise Exception('Magic Parse error: "%s"' % msg)
@@ -24,7 +25,18 @@ class MagicOptionParser(optparse.OptionParser):
     ## FIXME: override help to also stop processing
     ## currently --help gives syntax error
 
+
 class Magic(object):
+    """
+    Base class to define magics for MetaKernel based kernels.
+
+    Users can redefine the default magics provided by Metakernel
+    by creating a module with the exact same name as the
+    Metakernel magic.
+
+    For example, you can override %matplotlib in your kernel by
+    writing a new magic inside magics/matplotlib_magic.py
+    """
 
     def __init__(self, kernel):
         self.kernel = kernel


### PR DESCRIPTION
We're building an `ipdb` kernel for Spyder with MetaKernel. For that we defined Pdb commands as magics and some of their names collide with MetaKernel default magics.

With this PR users could create magics that are loaded instead of MetaKernel ones with the same name.