### PR TITLE
Fix for Python 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - IPYTHON="ipython"
 matrix:
   include:
+    - python: 2.7
     - python: 3.4
     - python: 3.5
     - python: 3.6

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -685,7 +685,7 @@ class MetaKernel(Kernel):
         ### if we are running via %parallel, we might not have a
         ### session
         if self.session:
-            super().send_response(*args, **kwargs)
+            super(MetaKernel, self).send_response(*args, **kwargs)
 
     def call_magic(self, line):
         """


### PR DESCRIPTION
@dsblank, @blink1073, we need to maintain Python 2 compatibility in Spyder until Python 2 end of life, so we would need MetaKernel to work with Python 2 until that date too.

To not add to you more work than you should be doing, we're willing to offer our time to keep maintaining Python 2 until that date.

Hope you're ok with that.