### PR TITLE
Fix TypeError

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -641,7 +641,7 @@ class MetaKernel(Kernel):
             if Widget and isinstance(item, Widget):
                 self.Display(item)
 
-        objects = [i for i in objects if not isinstance(i, Widget)]
+        objects = [i for i in objects if not (Widget and isinstance(i, Widget))]
         message = format_message(*objects, **kwargs)
 
         stream_content = {


### PR DESCRIPTION
````
>   objects = [i for i in objects if not isinstance(i, Widget)]
E   TypeError: isinstance() arg 2 must be a type or tuple of types
````
