### PR TITLE
kernel_javascript writes kernel.js to kernelspec

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -805,12 +805,16 @@ class MetaKernelApp(IPKernelApp):
                 self.argv = argv
 
             def start(self):
-                kernel_spec = self.kernel_class().kernel_json
+                instance = self.kernel_class()
+                kernel_spec = instance.kernel_json
                 with TemporaryDirectory() as td:
                     dirname = os.path.join(td, kernel_spec['name'])
                     os.mkdir(dirname)
                     with open(os.path.join(dirname, 'kernel.json'), 'w') as f:
                         json.dump(kernel_spec, f, sort_keys=True)
+                    if hasattr(instance, 'kernel_javascript') and instance.kernel_javascript.strip():
+                        with open(os.path.join(dirname, 'kernel.js'), 'w') as f:
+                            f.write(instance.kernel_javascript)
                     filenames = ['logo-64x64.png', 'logo-32x32.png']
                     name = self.kernel_class.__module__
                     for filename in filenames:


### PR DESCRIPTION
This way you can write kernel.js the same way we write the kernel.json, for say, a syntax highlighter:

```python
class MyKernel(Metakernel):
    kernel_javascript = """
define(
['codemirror/lib/codemirror', 'codemirror/addon/mode/simple'],
function(CodeMirror, _) {
  return {
    onload: function(){
        CodeMirror.defineSimpleMode('language_name', {
            start: [
                // defs here
            ]
        });
    }
  };
});
"""

    kernel_json = {
        'argv': [
            sys.executable, '-m', 'module_name', '-f', '{connection_file}'],
        'display_name': 'Name of Kernel',
        'language': 'language_name',
        'name': 'name_of_kernel'
    }
```