### PR TITLE
fix ipywidgets display

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -614,7 +614,23 @@ class MetaKernel(Kernel):
         for item in objects:
             if Widget and isinstance(item, Widget):
                 self.log.debug('Display Widget')
-                self._ipy_formatter(item)
+                data = {
+                    'text/plain': repr(item),
+                    'application/vnd.jupyter.widget-view+json': {
+                    'version_major': 2,
+                    'version_minor': 0,
+                    'model_id': item._model_id
+                    }
+                    }
+                content = {
+                    'data': data,
+                    'metadata': None
+                    }
+                self.send_response(
+                    self.iopub_socket,
+                    'display_data',
+                    content
+                )
             else:
                 self.log.debug('Display Data')
                 try:


### PR DESCRIPTION
This fixes #207 ipywidget display as well as ROOT-10971 for the ROOT kernel.
The protocol for displaying ipywidgets seems to have changed and simply
passing the mime bundle to ipython does not work.