### PR TITLE
fix python evals #208

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -373,7 +373,7 @@ class MetaKernel(Kernel):
                 magic = self.get_magic(code)
                 if magic is not None:
                     stack.append(magic)
-                    code = magic.get_code()
+                    code = str(magic.get_code())
                     # signal to exit, maybe error or no block
                     if not magic.evaluate:
                         break

--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -129,9 +129,9 @@ class PythonMagic(Magic):
         """
         if self.code.strip():
             if eval_output:
-                self.eval(self.code)
+                retval = self.eval(self.code)
                 self.code = str(self.env["retval"]) if ("retval" in self.env and
-                                                        self.env["retval"] != None) else ""
+                                                        self.env["retval"] != None) else retval
                 self.retval = None
                 self.env["retval"] = None
                 self.evaluate = True


### PR DESCRIPTION
This fixes python evals so that the code matches the comments.  Without
the patch the non-retval version of python eval will not work.