### PR TITLE
use TERM=dumb for bash REPLWrapper

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -307,7 +307,7 @@ def bash(command="bash", prompt_regex=re.compile('[$#]')):
     else:
         prompt_emit_cmd = None
 
-    extra_init_cmd = "export PAGER=cat"
+    extra_init_cmd = "export TERM=dumb PAGER=cat"
 
     # Make sure the bash shell has a valid ending character.
     bashrc = os.path.join(os.path.dirname(pexpect.PEXPECT_DIR), 'bashrc.sh')

--- a/metakernel/tests/test_replwrap.py
+++ b/metakernel/tests/test_replwrap.py
@@ -67,7 +67,7 @@ class REPLWrapTestCase(unittest.TestCase):
         child = pexpect.spawnu("bash", timeout=5, echo=False)
         repl = replwrap.REPLWrapper(child, re.compile('[$#]'),
                                     "PS1='{0}' PS2='{1}' "
-                                    "PROMPT_COMMAND=''")
+                                    "PROMPT_COMMAND='' TERM='dumb'")
 
         res = repl.run_command("echo $HOME")
         assert res.startswith('/'), res


### PR DESCRIPTION
Bash 5.1 enables bracketed paste mode by default when it detects that it
is connected to a [pt]ty. This causes extra terminal escape codes to be
emitted in the output, confusing pexpect. Setting TERM=dumb disables
this, allowing the bash REPLWrapper to function correctly.