### PR TITLE
add support for SOURCE_DATE_EPOCH

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, datetime
+import sys, os, datetime, time
+
+today = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -46,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Metakernel'
-copyright = u'2014 - {today.year}, Metakernel contributors'.format(today=datetime.date.today())
+copyright = u'2014 - {today.year}, Metakernel contributors'.format(today=today)
 
 import metakernel
 


### PR DESCRIPTION
As part of the Reproducible Builds effort [0] it was noticed that metakernel could not be built reproducibly due to the build year embedded in the documentation. The recommended approach is to use SOURCE_DATE_EPOCH [1].

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/