### PR TITLE
Support older jedi versions

### DIFF
--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -173,7 +173,11 @@ class PythonMagic(Magic):
             path, dot, like = completion_parts(path)
             before = text[:len(text) - len(like)]
 
-        completions = interpreter.complete()
+        try:
+            completions = interpreter.complete()
+        except AttributeError:
+            completions = interpreter.completions()
+
         completions = [before + c.name_with_symbols for c in completions]
 
         self.kernel.log.error(completions)


### PR DESCRIPTION
Compilation fails on e.g. Fedora 32:
```
>       completions = interpreter.complete()
E       AttributeError: 'Interpreter' object has no attribute 'complete'
```
