### PR TITLE
Add missing dollar signs to %latex examples and tests

### DIFF
--- a/metakernel/magics/README.md
+++ b/metakernel/magics/README.md
@@ -218,7 +218,7 @@ Options:
 This line magic will display the TEXT on the line as LaTeX.
 
 Example:
-    %latex x_1 = \dfrac{a}{b}
+    %latex $x_1 = \dfrac{a}{b}$
 
 ## `%load`
 
@@ -657,9 +657,9 @@ This cell magic will display the TEXT in the cell as LaTeX.
 
 Example:
     %%latex
-    x_1 = \dfrac{a}{b}
+    $x_1 = \dfrac{a}{b}$
 
-    x_2 = a^{n - 1}
+    $x_2 = a^{n - 1}$
 
 ## `%%macro`
 

--- a/metakernel/magics/latex_magic.py
+++ b/metakernel/magics/latex_magic.py
@@ -13,7 +13,7 @@ class LatexMagic(Magic):
         This line magic will display the TEXT on the line as LaTeX.
 
         Example:
-            %latex x_1 = \dfrac{a}{b}
+            %latex $x_1 = \dfrac{a}{b}$
 
         """
         latex = Latex(text)
@@ -27,9 +27,9 @@ class LatexMagic(Magic):
 
         Example:
             %%latex 
-            x_1 = \dfrac{a}{b}
+            $x_1 = \dfrac{a}{b}$
 
-            x_2 = a^{n - 1}
+            $x_2 = a^{n - 1}$
         """
         latex = Latex(self.code)
         self.kernel.Display(latex)

--- a/metakernel/magics/tests/test_latex_magic.py
+++ b/metakernel/magics/tests/test_latex_magic.py
@@ -5,15 +5,15 @@ from metakernel.tests.utils import (get_kernel, get_log_text,
 
 def test_latex_magic():
     kernel = get_kernel()
-    kernel.do_execute("%latex x_1 = \dfrace{a}{b}")
+    kernel.do_execute("%latex $x_1 = \\dfrac{a}{b}$")
     text = get_log_text(kernel)
     assert "Display Data" in text
 
     clear_log_text(kernel)
 
     kernel.do_execute("""%%latex
-            x_1 = \dfrac{a}{b}
+            $x_1 = \\dfrac{a}{b}$
 
-            x_2 = a^{n - 1}""")
+            $x_2 = a^{n - 1}$""")
     text = get_log_text(kernel)
     assert "Display Data" in text


### PR DESCRIPTION
The %latex and %%latex magics need dollar signs around equations. See the screen dump:

![metakernel-latex](https://user-images.githubusercontent.com/1931206/98437619-e1081380-20e3-11eb-9d1c-44c8f4674519.png)

This PR also addresses the warnings:
```
metakernel/magics/tests/test_latex_magic.py:8
  /builddir/build/BUILD/metakernel-0.27.3/metakernel/magics/tests/test_latex_magic.py:8: DeprecationWarning: invalid escape sequence \d
    kernel.do_execute("%latex x_1 = \dfrace{a}{b}")
metakernel/magics/tests/test_latex_magic.py:14
  /builddir/build/BUILD/metakernel-0.27.3/metakernel/magics/tests/test_latex_magic.py:14: DeprecationWarning: invalid escape sequence \d
    kernel.do_execute("""%%latex
```