### PR TITLE
Escape backslashes in strings

### DIFF
--- a/metakernel/tests/test_parser.py
+++ b/metakernel/tests/test_parser.py
@@ -71,7 +71,7 @@ def get_parser():
 def test_complete1():
     p = get_parser()
     info = p.parse_code('/tmp/')
-    assert "Test\ Dir/" in info['path_matches'], info['path_matches']
+    assert "Test\\ Dir/" in info['path_matches'], info['path_matches']
 
 
 def test_complete2():
@@ -101,7 +101,7 @@ def test_complete5():
 def test_complete6():
     p = get_parser()
     info = p.parse_code('/tmp/Test')
-    assert "Test\ Dir/" in info['path_matches'], info['path_matches']
+    assert "Test\\ Dir/" in info['path_matches'], info['path_matches']
 
 
 def test_complete7():
@@ -113,7 +113,7 @@ def test_complete7():
 def test_complete8():
     p = get_parser()
     info = p.parse_code('/tmp/Test Dir/', 0, 9)
-    assert 'Test\ Dir/' in info['path_matches'], info
+    assert 'Test\\ Dir/' in info['path_matches'], info
 
 
 def test_complete9():


### PR DESCRIPTION
Addresses these warnings:
```
metakernel/tests/test_parser.py:74
  /builddir/build/BUILD/metakernel-0.27.3/metakernel/tests/test_parser.py:74: DeprecationWarning: invalid escape sequence \ 
    assert "Test\ Dir/" in info['path_matches'], info['path_matches']
metakernel/tests/test_parser.py:104
  /builddir/build/BUILD/metakernel-0.27.3/metakernel/tests/test_parser.py:104: DeprecationWarning: invalid escape sequence \ 
    assert "Test\ Dir/" in info['path_matches'], info['path_matches']
metakernel/tests/test_parser.py:116
  /builddir/build/BUILD/metakernel-0.27.3/metakernel/tests/test_parser.py:116: DeprecationWarning: invalid escape sequence \ 
    assert 'Test\ Dir/' in info['path_matches'], info
-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
