### PR TITLE
Automated Changelog Entry for 0.28.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,33 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.28.0
+
+([Full Changelog](https://github.com/Calysto/metakernel/compare/0.27.5...246ae2090cbf7da4e428844fae49338708716866))
+
+### Maintenance and upkeep improvements
+
+- Add support for jupyter releaser [#234](https://github.com/Calysto/metakernel/pull/234) ([@blink1073](https://github.com/blink1073))
+- Modernize build and test [#233](https://github.com/Calysto/metakernel/pull/233) ([@blink1073](https://github.com/blink1073))
+
+### Other merged PRs
+
+- Fix Iframe display issue [#231](https://github.com/Calysto/metakernel/pull/231) ([@cathalmccabe](https://github.com/cathalmccabe))
+- Add a blockly magic instead of a jigsaw magic [#229](https://github.com/Calysto/metakernel/pull/229) ([@ChrisJaunes](https://github.com/ChrisJaunes))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/Calysto/metakernel/graphs/contributors?from=2020-11-09&to=2021-11-24&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Ablink1073+updated%3A2020-11-09..2021-11-24&type=Issues) | [@cathalmccabe](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Acathalmccabe+updated%3A2020-11-09..2021-11-24&type=Issues) | [@ChrisJaunes](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3AChrisJaunes+updated%3A2020-11-09..2021-11-24&type=Issues) | [@dsblank](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Adsblank+updated%3A2020-11-09..2021-11-24&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.27.5
 
 - Escape backslashes in strings [#226](https://github.com/Calysto/metakernel/pull/226) ([@ellert](https://github.com/ellert))
 - Add missing dollar signs to %latex examples and tests [#225](https://github.com/Calysto/metakernel/pull/225) ([@ellert](https://github.com/ellert))
 - Support older jedi versions [#224](https://github.com/Calysto/metakernel/pull/224) ([@ellert](https://github.com/ellert))
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.27.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,10 @@
 
 ## 0.28.0
 
-([Full Changelog](https://github.com/Calysto/metakernel/compare/0.27.5...246ae2090cbf7da4e428844fae49338708716866))
-
-### Maintenance and upkeep improvements
-
 - Add support for jupyter releaser [#234](https://github.com/Calysto/metakernel/pull/234) ([@blink1073](https://github.com/blink1073))
 - Modernize build and test [#233](https://github.com/Calysto/metakernel/pull/233) ([@blink1073](https://github.com/blink1073))
-
-### Other merged PRs
-
 - Fix Iframe display issue [#231](https://github.com/Calysto/metakernel/pull/231) ([@cathalmccabe](https://github.com/cathalmccabe))
 - Add a blockly magic instead of a jigsaw magic [#229](https://github.com/Calysto/metakernel/pull/229) ([@ChrisJaunes](https://github.com/ChrisJaunes))
-
-### Contributors to this release
-
-([GitHub contributors page for this release](https://github.com/Calysto/metakernel/graphs/contributors?from=2020-11-09&to=2021-11-24&type=c))
-
-[@blink1073](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Ablink1073+updated%3A2020-11-09..2021-11-24&type=Issues) | [@cathalmccabe](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Acathalmccabe+updated%3A2020-11-09..2021-11-24&type=Issues) | [@ChrisJaunes](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3AChrisJaunes+updated%3A2020-11-09..2021-11-24&type=Issues) | [@dsblank](https://github.com/search?q=repo%3ACalysto%2Fmetakernel+involves%3Adsblank+updated%3A2020-11-09..2021-11-24&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 


### PR DESCRIPTION
Automated Changelog Entry for 0.28.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | calysto/metakernel  |
| Branch  | master  |
| Version Spec | 0.28.0 |
| Since | 0.27.5 |