### PR TITLE
Fix trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python :: 3
     Framework :: IPython
-    opic :: System :: Shells
+    Topic :: System :: Shells
 
 [options]
 include_package_data = True


### PR DESCRIPTION
This prevented the release of 0.28.0.