### PR TITLE
Address deprecation warnings

### DIFF
--- a/metakernel/tests/test_expect.py
+++ b/metakernel/tests/test_expect.py
@@ -110,4 +110,4 @@ class ExpectTestCase (unittest.TestCase):
 if __name__ == '__main__':
     unittest.main()
 
-suite = unittest.makeSuite(ExpectTestCase, 'test')
+suite = unittest.TestLoader().loadTestsFromTestCase(ExpectTestCase)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
   "ignore:the imp module is deprecated:DeprecationWarning:ipykernel",
+  "ignore:The distutils package is deprecated:DeprecationWarning:ipykernel",
   "ignore:distutils Version classes:DeprecationWarning:ipyparallel",
   "ignore:unclosed event loop:ResourceWarning",
   "ignore:There is no current event loop:DeprecationWarning"


### PR DESCRIPTION
metakernel/tests/test_expect.py:113: in <module>
    suite = unittest.makeSuite(ExpectTestCase, 'test')
/usr/lib64/python3.11/unittest/loader.py:491: in makeSuite
    warnings.warn(
E   DeprecationWarning: unittest.makeSuite() is deprecated and will be removed in Python 3.13. Please use unittest.TestLoader.loadTestsFromTestCase() instead.

~~~
metakernel/__init__.py:1: in <module>
    from ._metakernel import (
metakernel/_metakernel.py:22: in <module>
    from ipykernel.kernelapp import IPKernelApp
/usr/lib/python3.10/site-packages/ipykernel/kernelapp.py:42: in <module>
    from .ipkernel import IPythonKernel
/usr/lib/python3.10/site-packages/ipykernel/ipkernel.py:19: in <module>
    from .eventloops import _use_appnope
/usr/lib/python3.10/site-packages/ipykernel/eventloops.py:13: in <module>
    from distutils.version import LooseVersion as V
/usr/lib64/python3.10/distutils/__init__.py:19: in <module>
    warnings.warn(_DEPRECATION_MESSAGE,
E   DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
~~~
