### PR TITLE
Strip paste-bracketing control characters

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -235,7 +235,7 @@ class REPLWrapper(object):
         for line in cmdlines[1:]:
             if not self.prompt_emit_cmd:
                 self._expect_prompt(timeout=timeout)
-                res.append(self.child.before)
+                res.append(strip_bracketing(self.child.before))
             self.sendline(line)
 
         # Command was fully submitted, now wait for the next prompt
@@ -246,7 +246,7 @@ class REPLWrapper(object):
 
         if self._stream_handler or self._line_handler:
             return u''
-        return u''.join(res + [self.child.before])
+        return u''.join(res + [strip_bracketing(self.child.before)])
 
     def interrupt(self, continuation=False):
         """Interrupt the process and wait for a prompt.
@@ -322,3 +322,11 @@ def bash(command="bash", prompt_regex=re.compile('[$#]')):
 def powershell(command='powershell', prompt_regex='>'):
     """"Start a powershell and return a :class:`REPLWrapper` object."""
     return REPLWrapper(command, prompt_regex, 'Function prompt {{ "{0}" }}', echo=True)
+
+
+def strip_bracketing(string, start='\x1b[?2004l', stop='\x1b[?2004h'):
+    """Strip 'bracketed paste' control characters, if they are present"""
+    if string.startswith(start) and string.endswith(stop):
+        return string[len(start):-len(stop)]
+    else:
+        return string

--- a/metakernel/tests/test_replwrap.py
+++ b/metakernel/tests/test_replwrap.py
@@ -86,6 +86,15 @@ class REPLWrapTestCase(unittest.TestCase):
         res = p.run_command('for a in range(3): print(a)\n')
         assert res.strip().splitlines() == ['0', '1', '2']
 
+    def test_bracketed_paste(self):
+        # Readline paste bracketing is easily toggled in bash, but can be harder elsewhere
+        # This tests that run_command() still works with it enabled (the default for readline,
+        # but overriden by bash and python)
+        bash = replwrap.bash()
+        bash.run_command("bind 'set enable-bracketed-paste on'")
+        res = bash.run_command("echo '1 2\n3 4'")
+        self.assertEqual(res.strip().splitlines(), ['1 2', '3 4'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes downstream https://github.com/blink1073/oct2py/issues/237 and https://github.com/blink1073/oct2py/issues/248 as well as addressing the cause behind #228 .

The rationale is complicated somewhat by the fact that python [disabled](https://bugs.python.org/issue42819) bracketed paste mode soon after #228, so that test doesn't fail anymore. I added a test that *would* fail without stripping the bracketing, by explicitly enabling it.

I think this is still the right place for this code (rather than downstream), since the readline default is to include the control characters, so I expect that stripping them will be common across multiple REPLs (including some `bash` invocations).