### PR TITLE
Restore versions of metakernel-echo and metakernel-python

### DIFF
--- a/metakernel_echo/metakernel_echo.py
+++ b/metakernel_echo/metakernel_echo.py
@@ -2,7 +2,7 @@
 from metakernel import MetaKernel
 import sys
 
-__version__ = "0.1.0"
+__version__ = "0.19.1"
 
 class MetaKernelEcho(MetaKernel):
     implementation = 'MetaKernel Echo'

--- a/metakernel_python/metakernel_python.py
+++ b/metakernel_python/metakernel_python.py
@@ -3,7 +3,7 @@ from IPython.core.inputtransformer2 import TransformerManager
 from metakernel import MetaKernel
 import sys
 
-__version__ = "0.1.0"
+__version__ = "0.19.1"
 
 class MetaKernelPython(MetaKernel):
     implementation = 'MetaKernel Python'


### PR DESCRIPTION
When the build system was updated the version information for
metakernel-echo and metakernel-python was lost and the versions
changed from 0.19.1 to 0.1.0. In order for the versions not to go
backwards on update this commit resets them to their previous values.