### PR TITLE
Add back magics tests

### DIFF
--- a/metakernel/magics/tests/test_parallel_magic.py
+++ b/metakernel/magics/tests/test_parallel_magic.py
@@ -2,7 +2,14 @@
 from metakernel.tests.utils import get_kernel, get_log_text, EvalKernel
 import os
 import time
+import pytest
 
+try:
+    import ipyparallel
+except ImportError:
+    ipyparallel = None
+
+@pytest.mark.skipif(ipyparallel is None, reason="Requires ipyparallel")
 def test_parallel_magic():
     kernel = get_kernel(EvalKernel)
     # start up an EvalKernel on each node:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 addopts= "-raXs  --durations 10 --color=yes --doctest-modules"
-testpaths = ["metakernel/tests"]
+testpaths = ["metakernel/tests", "metakernel/magics/tests"]
 timeout = 300
 # Restore this setting to debug failures
 # timeout_method = "thread"


### PR DESCRIPTION
The pytest configuration was recently changed from running tests in all directories except from a list of exclusions to running test only in a set of listed directories. In this change the magics tests in metakernel/magics/tests were lost. This PR puts them back.

Without the change:

    ============================= 40 passed in 23.08s ==============================

With the change:

    ======================== 79 passed, 3 skipped in 38.40s ========================
