### PR TITLE
Ignore DeprecationWarnings for datetime.utcnow()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,6 @@ filterwarnings= [
   "ignore:There is no current event loop:DeprecationWarning",
   # When we run ipcluster and then run the tests we get this warning
   "ignore:Widget.* is deprecated:DeprecationWarning",
+  # Deprecated in Python 3.12. Warnings from use in jupyter_client.
+  "ignore:datetime.utcnow.* is deprecated:DeprecationWarning",
 ]


### PR DESCRIPTION
It is deprecated in Python 3.12.
The call that causes the warning is in jupyter_client. This causes 56 tests to fail. First failure is:
~~~
_______________________________ test_get_magics ________________________________
    def test_get_magics():
>       kernel = get_kernel()
/builddir/build/BUILD/metakernel-0.29.4/metakernel/tests/test_magic.py:35: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ /builddir/build/BUILD/metakernel-0.29.4/metakernel/tests/utils.py:84: in get_kernel
    kernel = kernel_class(session=ss.Session(), iopub_socket=iopub_socket,
/usr/lib/python3.12/site-packages/jupyter_client/session.py:568: in __init__
    self._check_packers()
/usr/lib/python3.12/site-packages/jupyter_client/session.py:634: in _check_packers
    msg_datetime = dict(t=utcnow())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    def utcnow() -> datetime:
        """Return timezone-aware UTC timestamp"""
>       return datetime.utcnow().replace(tzinfo=utc)
E       DeprecationWarning: datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC).
/usr/lib/python3.12/site-packages/jupyter_client/session.py:203: DeprecationWarning
~~~
