### PR TITLE
Fix magic completion

### DIFF
--- a/metakernel/parser.py
+++ b/metakernel/parser.py
@@ -126,7 +126,10 @@ class Parser(object):
         info['obj'] = obj
         info['full_obj'] = full_obj
 
-        info['start'] = end - len(obj)
+        if obj:
+            info['start'] = end - len(obj)
+        else:
+            info['start'] = 0
         info['end'] = end
         info['pre'] = code[:start]
         info['code'] = code[start: end]


### PR DESCRIPTION
This PR fixes an edge case in magic completions:

Currently:

If you press TAB after `%` or `%%` and select an item it doubles the percents

Example:

%&lt;TAB> and select, say, `%cd` you'll get `%%cd`

After PR:

If you press TAB after `%` or `%%` and select an item it properly gives selection

Example:

%&lt;TAB> and select, say, `%cd` you'll get `%cd`
