### PR TITLE
Fix installation code blocks in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,25 +56,25 @@ Installation
 ----------------
 You can install Metakernel through ``pip``:
 
-.. code::bash
+.. code:: bash
 
  pip install metakernel --upgrade
 
 Installing `metakernel` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
-.. code::bash
+.. code:: bash
 
  conda config --add channels conda-forge
 
 Once the `conda-forge` channel has been enabled, `metakernel` can be installed with:
 
-.. code::bash
+.. code:: bash
 
  conda install metakernel
 
 It is possible to list all of the versions of `metakernel` available on your platform with:
 
-.. code::bash
+.. code:: bash
 
  conda search metakernel --channel conda-forge
 


### PR DESCRIPTION
Apparently something about .rst rendering changed in GitHub which requires a space between `code::` and the syntax to use now. Without the space it simply doesn't render which is quite confusing:
![image](https://github.com/Calysto/metakernel/assets/5768781/b91afed4-5cf3-4eb5-91bc-0e57696941dd)

With the fix in this PR:
![image](https://github.com/Calysto/metakernel/assets/5768781/09dc07e4-395d-4262-8760-f9bf10a3495a)
