### PR TITLE
Add `args` argument to `REPLWrapper` & `spawn()` to mimic `pty_spawn`

### DIFF
--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -24,8 +24,10 @@ def spawn(command, args=[], timeout=30, maxread=2000,
     '''
     codec_errors = kwargs.get('codec_errors', kwargs.get('errors', 'strict'))
     if pty is None:
-        command = shlex.split(command, posix=os.name == 'posix')
-        command += args
+        if args == []:
+            command = shlex.split(command, posix=os.name == 'posix')
+        else:
+            command += args
         child = PopenSpawn(command, timeout=timeout, maxread=maxread,
                            searchwindowsize=searchwindowsize,
                            logfile=logfile, cwd=cwd, env=env,

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -47,6 +47,7 @@ class REPLWrapper(object):
     we need to interrupt a continuation prompt.
     :param bool echo: Whether the child should echo, or in the case
     of Windows, whether the child does echo.
+    :param list args: Additional arguments to the spawning command
     """
 
     def __init__(self, cmd_or_spawn, prompt_regex, prompt_change_cmd,
@@ -56,9 +57,10 @@ class REPLWrapper(object):
                  extra_init_cmd=None,
                  prompt_emit_cmd=None,
                  force_prompt_on_continuation=False,
-                 echo=False):
+                 echo=False,
+                 args=[]):
         if isinstance(cmd_or_spawn, basestring):
-            self.child = pexpect.spawnu(cmd_or_spawn, echo=echo,
+            self.child = pexpect.spawnu(cmd_or_spawn, args, echo=echo,
                                         codec_errors="ignore",
                                         encoding="utf-8")
         else:

--- a/metakernel/tests/test_replwrap.py
+++ b/metakernel/tests/test_replwrap.py
@@ -95,6 +95,13 @@ class REPLWrapTestCase(unittest.TestCase):
         res = bash.run_command("echo '1 2\n3 4'")
         self.assertEqual(res.strip().splitlines(), ['1 2', '3 4'])
 
+    def test_spawn_args(self):
+        p = replwrap.REPLWrapper(sys.executable, ">>> ",
+                       "import sys; sys.ps1={0!r}; sys.ps2={1!r}", 
+                       args=['-i', '-c', 'x=4+7'])
+        res = p.run_command('x-11')
+        assert res.strip() == '0'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR originates from the issue related to [my recent PR to `octave_kernel`](https://github.com/Calysto/octave_kernel/pull/241): Re: space in the octave executable path. 

This PR contains two commits:

e800dca: This commit adds `args` list argument to the `REPLWrapper` constructor so it can be passed down to `spawn`. A test method has also been added to `test_replwrap.py`.

303f2fd: `pty_spawn` and non-`pty_spawn` codepaths currently handles `command` and `args` differently. This commit makes the non-`pty` path to be comparable to the `pty_spawn` implementation. That is, `command` is only split only if `args` is not provided.

These two mechanisms are essential to allow an octave executable path with spaces to run. If this PR is accepted, I will create another PR in `octave_kernel` to finish resolving the issue.

Thanks 