### PR TITLE
use ipython display formatter directly for missing _repr_mimebundle

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -17,11 +17,12 @@ from collections import OrderedDict
 
 warnings.filterwarnings('ignore', module='IPython.html.widgets')
 
+import comm
+import ipykernel # reconfigures comm
 from jupyter_core.paths import jupyter_config_path, jupyter_config_dir
 from IPython.paths import get_ipython_dir
 from ipykernel.kernelapp import IPKernelApp
 from ipykernel.kernelbase import Kernel
-from ipykernel.comm import CommManager
 from traitlets.config import Application
 from traitlets import Dict, Unicode
 
@@ -29,6 +30,7 @@ PY3 = sys.version_info[0] == 3
 
 try:
     from ipywidgets.widgets.widget import Widget
+    import ipywidgets as widgets
 except ImportError:
     Widget = None
 
@@ -41,7 +43,7 @@ except:
     RED = TermColors.Red
     NORMAL = TermColors.Normal
 
-from IPython.core.formatters import IPythonDisplayFormatter
+from IPython.core.formatters import DisplayFormatter
 from IPython.display import HTML
 from IPython.display import publish_display_data
 from IPython.utils.tempdir import TemporaryDirectory
@@ -152,9 +154,14 @@ class MetaKernel(Kernel):
                   'kernel': self}
         if not PY3:
             kwargs['shell'] = None
-        self.comm_manager = CommManager(**kwargs)
+        self.comm_manager = comm.get_comm_manager()
+        # widgets have changed target name in 8.x, keeping for compatibility
         self.comm_manager.register_target('ipython.widget',
             lazy_import_handle_comm_opened)
+
+        # compatible with widgets 8.x
+        if Widget is not None:
+            widgets.register_comm_target()
 
         self.hist_file = get_history_file(self)
         self.parser = Parser(self.identifier_regex, self.func_call_regex,
@@ -162,7 +169,7 @@ class MetaKernel(Kernel):
         comm_msg_types = ['comm_open', 'comm_msg', 'comm_close']
         for msg_type in comm_msg_types:
             self.shell_handlers[msg_type] = getattr(self.comm_manager, msg_type)
-        self._ipy_formatter = IPythonDisplayFormatter()
+        self._display_formatter = DisplayFormatter() # pass kwargs?
         self.env = {}
         self.reload_magics()
         # provide a way to get the current instance
@@ -437,7 +444,7 @@ class MetaKernel(Kernel):
                     self.send_response(self.iopub_socket, 'error', content)
             else:
                 try:
-                    data = _formatter(retval, self.repr)
+                    data = self._display_formatter.format(retval)
                 except Exception as e:
                     self.Error(e)
                     return
@@ -637,7 +644,7 @@ class MetaKernel(Kernel):
             else:
                 self.log.debug('Display Data')
                 try:
-                    data = _formatter(item, self.repr)
+                    data = self._display_formatter.format(item)
                 except Exception as e:
                     self.Error(e)
                     return
@@ -906,52 +913,6 @@ def _split_magics_code(code, prefixes):
         ret_code_str += "\n"
     return (ret_magics_str, ret_code_str)
 
-
-def _formatter(data, repr_func):
-    reprs = {}
-    reprs['text/plain'] = repr_func(data)
-
-    lut = [("_repr_png_", "image/png"),
-           ("_repr_jpeg_", "image/jpeg"),
-           ("_repr_html_", "text/html"),
-           ("_repr_markdown_", "text/markdown"),
-           ("_repr_svg_", "image/svg+xml"),
-           ("_repr_latex_", "text/latex"),
-           ("_repr_json_", "application/json"),
-           ("_repr_javascript_", "application/javascript"),
-           ("_repr_pdf_", "application/pdf")]
-
-    for (attr, mimetype) in lut:
-        obj = getattr(data, attr, None)
-        if obj:
-            reprs[mimetype] = obj
-
-    format_dict = {}
-    metadata_dict = {}
-    for (mimetype, value) in reprs.items():
-        metadata = None
-        try:
-            value = value()
-        except Exception:
-            pass
-        if not value:
-            continue
-        if isinstance(value, tuple):
-            metadata = value[1]
-            value = value[0]
-        if isinstance(value, bytes):
-            try:
-                value = value.decode('utf-8')
-            except Exception:
-                value = base64.encodestring(value)
-                value = value.decode('utf-8')
-        try:
-            format_dict[mimetype] = str(value)
-        except:
-            format_dict[mimetype] = value
-        if metadata is not None:
-            metadata_dict[mimetype] = metadata
-    return (format_dict, metadata_dict)
 
 
 def format_message(*objects, **kwargs):

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -18,7 +18,7 @@ class HelpMagic(Magic):
         ]
         strings = []
         if self.kernel.help_suffix:
-            strings += [s.format(self.kernel.help_suffix['help'])
+            strings += [s.format(self.kernel.help_suffix)
                         for s in suffixes]
         if 'help' in self.kernel.magic_prefixes:
             strings += [p.format(self.kernel.magic_prefixes['help'])
@@ -98,7 +98,7 @@ class HelpMagic(Magic):
                     return magic.get_help(minfo['type'], minfo['name'],
                                           level)
                 else:
-                    return ("No such %s magic named '%s', so can't really help with that" % 
+                    return ("No such %s magic named '%s', so can't really help with that" %
                             (minfo["type"], minfo["name"]))
             if magic:
                 the_help = magic.get_help_on(info, level)


### PR DESCRIPTION
Also fix #232, #284

I am not sure this will be fully backwards compatible, IPython code mentions that `_repr_mimebundle_` is there since 6.x and the `DisplayFormatter` should take care of rendering all registered mimetypes, but still.

My problem was that graphviz `Source` objects expose only `_repr_mimebundle` which is not used by the metakernel so I had to wrap that, but this looks like a simple enough fix that worked for me. `DisplayFormatter` can be configured, perhaps the kernel kwargs should be passed to it, not sure.