### PR TITLE
Do no wait for the default prompt on startup

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -109,7 +109,6 @@ class REPLWrapper(object):
             self.child.readline()
 
     def set_prompt(self, prompt_regex, prompt_change_cmd):
-        self.child.expect(prompt_regex)
         self.sendline(prompt_change_cmd)
         self.prompt_change_cmd = prompt_change_cmd
 


### PR DESCRIPTION
If the user defined a custom prompt, the expect on default prompt always timeout before setting the new prompt.