### PR TITLE
Fix exception in help_magic.py

### DIFF
--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -18,7 +18,7 @@ class HelpMagic(Magic):
         ]
         strings = []
         if self.kernel.help_suffix:
-            strings += [s.format(self.kernel.help_suffix['help'])
+            strings += [s.format(self.kernel.help_suffix)
                         for s in suffixes]
         if 'help' in self.kernel.magic_prefixes:
             strings += [p.format(self.kernel.magic_prefixes['help'])


### PR DESCRIPTION
Minimum change to fix https://github.com/Calysto/metakernel/issues/232

```
%magic
---
Error in calling magic 'magic' on line:
    string indices must be integers, not 'str'
```