### PR TITLE
Remove Python 2 compatibility shims and modernize string formatting

### DIFF
--- a/metakernel/__init__.py
+++ b/metakernel/__init__.py
@@ -12,7 +12,7 @@ from ._metakernel import (
 from .magic import Magic, option
 from .parser import Parser
 from .process_metakernel import ProcessMetaKernel
-from .replwrap import REPLWrapper, u
+from .replwrap import REPLWrapper
 
 __all__ = [
     "ExceptionWrapper",
@@ -27,7 +27,6 @@ __all__ = [
     "option",
     "pexpect",
     "register_ipython_magics",
-    "u",
 ]
 
 __version__ = "0.30.4"

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -180,11 +180,11 @@ class MetaKernel(Kernel):
             self.redirect_to_log = True
             self.Write("Executing files...")
             for filename in self.parent.extra_args:
-                self.Write("    %s..." % filename)
+                self.Write(f"    {filename}...")
                 try:
                     self.do_execute_file(filename)
                 except Exception as exc:
-                    self.log.info("    %s" % (exc,))
+                    self.log.info(f"    {exc}")
             self.Write("Executing files: done!")
             self.log.setLevel(level)
             self.redirect_to_log = False
@@ -237,7 +237,7 @@ class MetaKernel(Kernel):
         if none_on_fail:
             return None
         else:
-            return "Sorry, no help is available on '%s'." % info["code"]
+            return "Sorry, no help is available on '{}'.".format(info["code"])
 
     def handle_plot_settings(self) -> None:
         """Handle the current plot settings"""
@@ -292,7 +292,7 @@ class MetaKernel(Kernel):
         elif code.startswith("inspect "):
             raise Exception("This kernel does not implement this meta command")
         else:
-            raise Exception("Unknown meta command: '%s'" % code)
+            raise Exception(f"Unknown meta command: '{code}'")
 
     def initialize_debug(self, code: str) -> str:
         """
@@ -676,7 +676,7 @@ class MetaKernel(Kernel):
         message = format_message(*non_widgets, **kwargs)
 
         stream_content = {"name": "stdout", "text": message}
-        self.log.debug("Print: %s" % message.rstrip())
+        self.log.debug(f"Print: {message.rstrip()}")
         if self.redirect_to_log:
             self.log.info(message.rstrip())
         else:
@@ -685,7 +685,7 @@ class MetaKernel(Kernel):
     def Write(self, message: str) -> None:
         """Write message directly to the iopub stdout with no added end character."""
         stream_content = {"name": "stdout", "text": message}
-        self.log.debug("Write: %s" % message)
+        self.log.debug(f"Write: {message}")
         if self.redirect_to_log:
             self.log.info(message)
         else:
@@ -697,7 +697,7 @@ class MetaKernel(Kernel):
         Objects are cast to strings.
         """
         message = format_message(*objects, **kwargs)
-        self.log.debug("Error: %s" % message.rstrip())
+        self.log.debug(f"Error: {message.rstrip()}")
         stream_content = {"name": "stderr", "text": RED + message + NORMAL}
         if self.redirect_to_log:
             self.log.info(message.rstrip())
@@ -728,7 +728,7 @@ class MetaKernel(Kernel):
         message = format_message(" ".join(msg), **kwargs)
         if len(msg_dict.keys()) > 0:
             message = format_message(" ".join(msg), msg_dict)
-        self.log.debug("Error: %s" % message.rstrip())
+        self.log.debug(f"Error: {message.rstrip()}")
         stream_content = {"name": "stderr", "text": RED + message + NORMAL}
         if self.redirect_to_log:
             self.log.info(message.rstrip())
@@ -775,7 +775,7 @@ class MetaKernel(Kernel):
                 importlib.reload(module)
                 module.register_magics(self)
             except Exception as e:
-                self.log.error("Can't load '%s': error: %s" % (magic, e))
+                self.log.error(f"Can't load '{magic}': error: {e}")
 
     def register_magics(self, magic_klass: type[Magic]) -> None:
         """Register magics for a given magic_klass."""

--- a/metakernel/images/dragon.py
+++ b/metakernel/images/dragon.py
@@ -88,12 +88,12 @@ def makePicture(size: int) -> Any:
     pic.setTransparent(Color(bg))
     # pic.flipHorizontal()
     # show(pic)
-    pic.savePicture("logo-%dx%d.png" % (size, size))
+    pic.savePicture(f"logo-{size}x{size}.png")
     return pic
 
 
 for size in [32, 64]:  # 16, 32, 64, 128, 256, 512]:
     pic = makePicture(size)
-    show(pic, "%sx%s" % (size, size))
+    show(pic, f"{size}x{size}")
     # pic.savePicture("metakernel-logo-%sx%s.gif" % (size, size))
     # pic.savePicture("metakernel-logo-%sx%s.jpg" % (size, size))

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -21,7 +21,7 @@ PY3 = sys.version_info[0] == 3
 
 class MagicOptionParser(optparse.OptionParser):
     def error(self, msg: str) -> NoReturn:
-        raise Exception('Magic Parse error: "%s"' % msg)
+        raise Exception(f'Magic Parse error: "{msg}"')
 
     def exit(self, status: int = 0, msg: Any = None) -> NoReturn:
         if msg:
@@ -100,10 +100,7 @@ class Magic:
             except TypeError:
                 func(old_args)
         except Exception as exc:
-            msg = (
-                "Error in calling magic '%s' on %s:\n    %s\n    args: %s\n    kwargs: %s"
-                % (name, mtype, str(exc), args, kwargs)
-            )
+            msg = f"Error in calling magic '{name}' on {mtype}:\n    {exc!s}\n    args: {args}\n    kwargs: {kwargs}"
             self.kernel.Error(msg)
             self.kernel.Error(traceback.format_exc())
             self.kernel.Error(self.get_help(mtype, name))
@@ -118,19 +115,19 @@ class Magic:
                 if func.__doc__:
                     return _trim(func.__doc__)  # type: ignore[return-value]
                 else:
-                    return "No help available for magic '%s' for %ss." % (name, mtype)
+                    return f"No help available for magic '{name}' for {mtype}s."
             else:
                 filename = inspect.getfile(func)
                 if filename and os.path.exists(filename):
                     with open(filename) as f:
                         return f.read()
                 else:
-                    return "No help available for magic '%s' for %ss." % (name, mtype)
+                    return f"No help available for magic '{name}' for {mtype}s."
         else:
-            return "No such magic '%s' for %ss." % (name, mtype)
+            return f"No such magic '{name}' for {mtype}s."
 
     def get_help_on(self, info: dict[str, Any], level: int = 0) -> str | None:
-        return "Sorry, no help is available on '%s'." % info["code"]
+        return "Sorry, no help is available on '{}'.".format(info["code"])
 
     def get_completions(self, info: dict[str, Any]) -> list[str]:
         """
@@ -273,7 +270,7 @@ def _format_option(option: Any) -> str:
     output += " " * (15 - len(output))
     output += option.help + " "
     if not option.default == ("NO", "DEFAULT"):
-        output += "[default: %s]" % option.default
+        output += f"[default: {option.default}]"
     return str(output)
 
 

--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -106,7 +106,7 @@ class Activity:
             self.choice_row_list.append(
                 widgets.HBox(
                     [
-                        widgets.HTML("<b>%s</b>)&nbsp;&nbsp;" % count),
+                        widgets.HTML(f"<b>{count}</b>)&nbsp;&nbsp;"),
                         self.choice_widgets[-1],
                     ]
                 )
@@ -144,10 +144,10 @@ class Activity:
         )
 
     def set_question(self, question: str) -> None:
-        self.question_widget.value = "<h1>%s</h1>" % question
+        self.question_widget.value = f"<h1>{question}</h1>"
 
     def set_id(self, id: Any) -> None:
-        self.id_widget.value = "<p><b>Question ID</b>: %s</p>" % id
+        self.id_widget.value = f"<p><b>Question ID</b>: {id}</p>"
         self.id = id
 
     def handle_results(self, sender: Any) -> None:
@@ -200,13 +200,7 @@ class Activity:
 
         with portalocker.Lock(self.results_filename, "a+") as g:
             g.write(
-                "%s::%s::%s::%s\n"
-                % (
-                    self.id,
-                    getpass.getuser(),
-                    datetime.datetime.today(),
-                    sender.description,
-                )
+                f"{self.id}::{getpass.getuser()}::{datetime.datetime.today()}::{sender.description}\n"
             )
             g.flush()
             os.fsync(g.fileno())
@@ -301,11 +295,11 @@ class ActivityMagic(Magic):
       }
    ]
 }'''
-            get_ipython().set_next_input(("%%%%activity %s\n\n" % filename) + text)
+            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
             return
         elif mode == "edit":
             text = "".join(open(filename).readlines())
-            get_ipython().set_next_input(("%%%%activity %s\n\n" % filename) + text)
+            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
         else:
             activity = Activity()
             activity.load(filename)

--- a/metakernel/magics/connect_info_magic.py
+++ b/metakernel/magics/connect_info_magic.py
@@ -46,29 +46,26 @@ class ConnectInfoMagic(Magic):
                 "signature_scheme": "UNKNOWN",
                 "transport": "UNKNOWN",
             }
-        retval = (
-            """{
-  "stdin_port": %(stdin_port)s,
-  "shell_port": %(shell_port)s,
-  "iopub_port": %(iopub_port)s,
-  "hb_port": %(hb_port)s,
-  "ip": "%(ip)s",
-  "key": "%(key)s",
-  "signature_scheme": "%(signature_scheme)s",
-  "transport": "%(transport)s"
-}
+        retval = """{{
+  "stdin_port": {stdin_port},
+  "shell_port": {shell_port},
+  "iopub_port": {iopub_port},
+  "hb_port": {hb_port},
+  "ip": "{ip}",
+  "key": "{key}",
+  "signature_scheme": "{signature_scheme}",
+  "transport": "{transport}"
+}}
 
 Paste the above JSON into a file, and connect with:
     $> ipython <app> --existing <file>
 or, if you are local, you can connect with just:
-    $> ipython <app> --existing %(key)s
+    $> ipython <app> --existing {key}
 
 or even just:
     $> ipython <app> --existing
 if this is the most recent Jupyter session you have started.
-"""
-            % config
-        )
+""".format(**config)
         self.kernel.Print(retval)
 
 

--- a/metakernel/magics/conversation_magic.py
+++ b/metakernel/magics/conversation_magic.py
@@ -13,21 +13,18 @@ class ConversationMagic(Magic):
         %conversation ID - insert conversation by ID
         %%conversation ID - insert conversation by ID
         """
-        html = (
-            """
+        html = f"""
 <div id="disqus_thread"></div>
 <script>
-(function() { // DON'T EDIT BELOW THIS LINE
+(function() {{ // DON'T EDIT BELOW THIS LINE
     var d = document, s = d.createElement('script');
-    s.src = '//%s.disqus.com/embed.js';
+    s.src = '//{id}.disqus.com/embed.js';
     s.setAttribute('data-timestamp', +new Date());
     (d.head || d.body).appendChild(s);
-})();
+}})();
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 """
-            % id
-        )
         self.kernel.Display(HTML(html))
 
     def line_conversation(self, id) -> None:

--- a/metakernel/magics/debug_magic.py
+++ b/metakernel/magics/debug_magic.py
@@ -212,7 +212,7 @@ function reset() {
         )  ## add a line so line numbers will be correct
         time.sleep(0.1)
         if data.startswith("highlight: "):
-            self.kernel.Display(Javascript("highlight(cell, %s);" % data[11:]))
+            self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))
         time.sleep(0.1)
         self.evaluate = False
 

--- a/metakernel/magics/download_magic.py
+++ b/metakernel/magics/download_magic.py
@@ -45,7 +45,7 @@ class DownloadMagic(Magic):
                 path = parts[2]
                 filename = os.path.basename(path)
             else:
-                raise Exception("invalid arguments to %%download: '%s'" % url)
+                raise Exception(f"invalid arguments to %download: '{url}'")
         _basename, extname = os.path.splitext(filename)
         if extname == "":
             filename += ".html"
@@ -53,7 +53,7 @@ class DownloadMagic(Magic):
         filename = filename.replace("%20", "_")
         try:
             download(url, filename)
-            self.kernel.Print("Downloaded '%s'." % filename)
+            self.kernel.Print(f"Downloaded '{filename}'.")
         except Exception as e:
             self.kernel.Error(str(e))
 

--- a/metakernel/magics/file_magic.py
+++ b/metakernel/magics/file_magic.py
@@ -42,11 +42,11 @@ class FileMagic(Magic):
                 raise
         # Create or append to file:
         if not append:
-            message = "Created file '%s'." % filename
+            message = f"Created file '{filename}'."
             if os.path.isfile(self.code):
-                message = "Overwrote file '%s'." % filename
+                message = f"Overwrote file '{filename}'."
         else:
-            message = "Appended on file '%s'." % filename
+            message = f"Appended on file '{filename}'."
         try:
             if append:
                 fp = open(filename, "a")

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -75,7 +75,7 @@ class HelpMagic(Magic):
 
         if info["magic"]:
             minfo = info["magic"]
-            errmsg = "No such %s magic '%s'" % (minfo["type"], minfo["name"])
+            errmsg = "No such {} magic '{}'".format(minfo["type"], minfo["name"])
 
             if minfo["type"] == "line":
                 magic = self.kernel.line_magics.get(minfo["name"], None)
@@ -96,9 +96,8 @@ class HelpMagic(Magic):
                     assert isinstance(magic, Magic)
                     return magic.get_help(minfo["type"], minfo["name"], level)
                 else:
-                    return (
-                        "No such %s magic named '%s', so can't really help with that"
-                        % (minfo["type"], minfo["name"])
+                    return "No such {} magic named '{}', so can't really help with that".format(
+                        minfo["type"], minfo["name"]
                     )
             if magic:
                 assert isinstance(magic, Magic)

--- a/metakernel/magics/install_magic.py
+++ b/metakernel/magics/install_magic.py
@@ -42,7 +42,7 @@ class InstallMagic(Magic):
             filename = os.path.expanduser(filename)
         filename = os.path.abspath(filename)
         text = open(filename).read()
-        if ('IPython.load_extensions("%s");' % name) in text:
+        if (f'IPython.load_extensions("{name}");') in text:
             return
         if "// INSTALL MAGIC" not in text:
             text += """
@@ -56,7 +56,7 @@ require(["base/js/events"], function (events) {
 """
         text = text.replace(
             "        // INSTALL MAGIC",
-            '        IPython.load_extensions("%s");\n        // INSTALL MAGIC' % name,
+            f'        IPython.load_extensions("{name}");\n        // INSTALL MAGIC',
         )
         with open(filename, "w") as fp:
             fp.write(text)

--- a/metakernel/magics/install_magic_magic.py
+++ b/metakernel/magics/install_magic_magic.py
@@ -33,7 +33,7 @@ class InstallMagicMagic(Magic):
         magic_filename = os.path.join(self.kernel.get_local_magics_dir(), filename)
         try:
             download(url, magic_filename)
-            self.kernel.Print("Downloaded '%s'." % magic_filename)
+            self.kernel.Print(f"Downloaded '{magic_filename}'.")
             self.code = "%reload_magics\n" + self.code
         except Exception as e:
             self.kernel.Error(str(e))

--- a/metakernel/magics/macro_magic.py
+++ b/metakernel/magics/macro_magic.py
@@ -60,7 +60,7 @@ class MacroMagic(Magic):
         if list:
             self._list_macros(name)
         elif show:
-            retval = "%%%%macro %s\n" % name
+            retval = f"%%macro {name}\n"
             if name in self.macros:
                 retval += self.macros[name]
             elif name in self.learned:
@@ -86,7 +86,7 @@ class MacroMagic(Magic):
         elif name == "":
             self._list_macros()
         else:
-            self._list_macros(retval="No such macro: '%s'\n\n" % name, error=True)
+            self._list_macros(retval=f"No such macro: '{name}'\n\n", error=True)
         self.evaluate = True
 
     def _list_macros(self, name="all", retval="", error=False) -> None:
@@ -94,11 +94,11 @@ class MacroMagic(Magic):
         if name in ["all", "system"]:
             retval += "    System:\n"
             for macro in sorted(self.macros.keys()):
-                retval += "        %s\n" % macro
+                retval += f"        {macro}\n"
         if name in ["all", "learned"]:
             retval += "    Learned:\n"
             for macro in sorted(self.learned.keys()):
-                retval += "        %s\n" % macro
+                retval += f"        {macro}\n"
         if error:
             self.kernel.Error(retval)
         else:

--- a/metakernel/magics/magic_magic.py
+++ b/metakernel/magics/magic_magic.py
@@ -38,7 +38,7 @@ class MagicMagic(Magic):
         self.kernel.Print("")
         self.kernel.Print("Shell shortcut:")
         self.kernel.Print(
-            "    %s COMMAND ... - execute command in shell" % prefixes["shell"]
+            "    {} COMMAND ... - execute command in shell".format(prefixes["shell"])
         )
         self.kernel.Print("")
         self.kernel.Print(
@@ -63,12 +63,12 @@ class MagicMagic(Magic):
             sname = (self.kernel.magic_prefixes["magic"] * 2) + name
             if sname in self.kernel.sticky_magics:
                 del self.kernel.sticky_magics[sname]
-                self.kernel.Print("%s removed from session magics.\n" % sname)
+                self.kernel.Print(f"{sname} removed from session magics.\n")
                 # dummy magic to eat this line and continue:
                 return Magic(self.kernel)
             else:
                 self.kernel.sticky_magics[sname] = minfo["args"]
-                self.kernel.Print("%s added to session magics.\n" % name)
+                self.kernel.Print(f"{name} added to session magics.\n")
 
         cell_magics = self.kernel.cell_magics
         line_magics = self.kernel.line_magics

--- a/metakernel/magics/processing_magic.py
+++ b/metakernel/magics/processing_magic.py
@@ -33,19 +33,16 @@ class ProcessingMagic(Magic):
             repr_code = repr_code[1:]
 
         env = {"code": repr_code, "id": self.canvas_id}
-        code = (
-            """
-<canvas id="canvas_%(id)s"></canvas>
+        code = """
+<canvas id="canvas_{id}"></canvas>
 <script>
-require([window.location.protocol + "//calysto.github.io/javascripts/processing/processing.js"], function () {
-    var processingCode = %(code)s;
+require([window.location.protocol + "//calysto.github.io/javascripts/processing/processing.js"], function () {{
+    var processingCode = {code};
     var cc = Processing.compile(processingCode);
-    var processingInstance = new Processing("canvas_%(id)s", cc);
-});
+    var processingInstance = new Processing("canvas_{id}", cc);
+}});
 </script>
-"""
-            % env
-        )
+""".format(**env)
         html = HTML(code)
         self.kernel.Display(html)
         self.evaluate = False

--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -39,7 +39,7 @@ def exec_then_eval(code: str, env: dict[str, Any]) -> Any:
         ex_type, ex, tb = sys.exc_info()
         line1 = ["Traceback (most recent call last):"]
         ex_name = ex_type.__name__ if ex_type is not None else "Exception"
-        line2 = ["%s: %s" % (ex_name, str(ex))]
+        line2 = [f"{ex_name}: {ex!s}"]
         tb_format = (
             line1 + [line.rstrip() for line in traceback.format_tb(tb)[1:]] + line2
         )
@@ -184,7 +184,7 @@ class PythonMagic(Magic):
 
         last = info["obj"]
 
-        default = None if none_on_fail else ('No help available for "%s"' % last)
+        default = None if none_on_fail else (f'No help available for "{last}"')
 
         parts = last.split(".")
 

--- a/metakernel/magics/shell_magic.py
+++ b/metakernel/magics/shell_magic.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from typing import Any
 
 from metakernel import Magic, pexpect
 from metakernel.replwrap import REPLWrapper, bash, powershell
@@ -13,8 +13,8 @@ from metakernel.replwrap import REPLWrapper, bash, powershell
 class ShellMagic(Magic):
     def __init__(self, kernel) -> None:
         super().__init__(kernel)
-        self.repl: Optional[REPLWrapper] = None
-        self.cmd: Optional[str] = None
+        self.repl: REPLWrapper | None = None
+        self.cmd: str | None = None
         self.start_process()
 
     def line_shell(self, *args) -> None:
@@ -35,7 +35,7 @@ class ShellMagic(Magic):
 
         """
         # get in sync with the cwd
-        self.eval('cd "%s"' % os.getcwd().replace(os.path.sep, "/"))
+        self.eval('cd "{}"'.format(os.getcwd().replace(os.path.sep, "/")))
 
         command = " ".join(args)
         self.eval(command, True)
@@ -94,22 +94,22 @@ class ShellMagic(Magic):
     def get_completions(self, info) -> list[str]:
         if self.cmd == "cmd":
             return []
-        command = 'compgen -cdfa "%s"' % info["code"]
+        command = 'compgen -cdfa "{}"'.format(info["code"])
         completion_text = self.eval(command)
         return completion_text.split()
 
     def get_help_on(self, info: dict[str, Any], level: int = 0) -> str:
         expr = info["code"].rstrip()
         if self.cmd == "cmd":
-            resp = self.eval("help %s" % expr)
+            resp = self.eval(f"help {expr}")
         elif level == 0:
-            resp = self.eval("%s --help" % expr)
+            resp = self.eval(f"{expr} --help")
         else:
-            resp = self.eval("man %s" % expr)
+            resp = self.eval(f"man {expr}")
         if resp and ": command not found" not in resp:
             return resp
         else:
-            return "Sorry, no help is available on '%s'." % expr
+            return f"Sorry, no help is available on '{expr}'."
 
 
 def register_magics(kernel) -> None:

--- a/metakernel/parser.py
+++ b/metakernel/parser.py
@@ -48,7 +48,7 @@ class Parser:
         self.unquoted_path = re.compile(
             rf"\A{full_path_regex}| {full_path_regex}", re.UNICODE
         )
-        self.quoted_path = re.compile(r'[\'"]%s' % full_path_regex, re.UNICODE)
+        self.quoted_path = re.compile(rf'[\'"]{full_path_regex}', re.UNICODE)
 
         single_path_regex = r"([\w/\.~][^ ]*)\Z"
         self.single_path = re.compile(single_path_regex, re.UNICODE)
@@ -194,7 +194,7 @@ class Parser:
 
         pre_magics = {}
         for name, prefix in self.magic_prefixes.items():
-            match = re.match(r"(\%s+)" % prefix, code, re.UNICODE)
+            match = re.match(rf"(\{prefix}+)", code, re.UNICODE)
             if match:
                 pre_magics[name] = match.groups()[0]
 
@@ -210,7 +210,7 @@ class Parser:
 
         elif self.help_suffix and code.rstrip().endswith(self.help_suffix):
             info["name"] = "help"
-            regex = r"(\%s+)\Z" % self.help_suffix
+            regex = rf"(\{self.help_suffix}+)\Z"
             match = re.search(regex, code.strip(), re.UNICODE)
             assert match is not None
             suf = match.group()

--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -92,7 +92,7 @@ def spawn(
 spawnu = spawn
 
 
-def which(filename: str) -> Optional[str]:
+def which(filename: str) -> str | None:
     """This takes a given filename; tries to find it in the environment path;
     then checks if it is executable. This returns the full path to the filename
     if found and executable. Otherwise this returns None."""

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import sys
 from subprocess import check_output
-from typing import Any, Optional
+from typing import Any
 
 from pexpect import EOF
 
@@ -58,7 +58,7 @@ class ProcessMetaKernel(MetaKernel):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         MetaKernel.__init__(self, *args, **kwargs)
-        self.wrapper: Optional[REPLWrapper] = None
+        self.wrapper: REPLWrapper | None = None
 
     def do_execute_direct(self, code: str, silent: bool = False) -> TextOutput | None:
         """Execute the code in the subprocess."""
@@ -232,7 +232,7 @@ class DynamicKernel(ProcessMetaKernel):
     """
     DynamicKernel(executable="bash",
                   orig_prompt=re.compile('[$#]'),
-                  prompt_change=u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''",
+                  prompt_change="PS1='{0}' PS2='{1}' PROMPT_COMMAND=''",
                   prompt_cmd=None,
                   extra_init_cmd="export PAGER=cat",
                   implementation="bash_kernel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ extend-select = [
   "RUF",    # Ruff-specific
   "UP",     # pyupgrade
 ]
-ignore = ["RUF012", "UP031", "RUF005", "UP045"]
+ignore = ["RUF012", "RUF005"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["UP031", "E402", "RUF012", "F841"]


### PR DESCRIPTION
## Summary

- Remove `u()` pass-through function and `basestring = str` alias from `replwrap.py`
- Remove `u` from `__init__.py` public API (`import` and `__all__`)
- Strip all `u"..."` string prefixes and `u(...)` call wrappers throughout the codebase
- Convert `%-format` strings to f-strings (UP031) across all modules
- Convert `Optional[X]` type annotations to `X | None` (UP045)
