### PR TITLE
Add test module for blockly magic and fix register_magics bug

### DIFF
--- a/metakernel/magics/README.md
+++ b/metakernel/magics/README.md
@@ -12,6 +12,26 @@ Examples:
     %activity /home/teacher/activity1 new
     %activity /home/teacher/activity1 edit
 
+## `%blockly`
+
+%blockly - show visual code
+
+This line magic will allow visual code editing
+If both -o and -l are provided, only -l is used
+
+Examples:
+    %blockly --page_from_origin http://host[:port]/blockly_page.html
+    %blockly --page_from_local blockly_page.html
+    %blockly --page_from_origin http://host[:port]/blockly_template.html --template_data template_data
+    %blockly --height 600
+
+Options:
+--------
+-h --height    set height of iframe  [default: 350]
+-t --template_data generate page based on template and load, must be used with parameters(-o or -l) [default: None]
+-l --page_from_local Load local page about blockly [default: None]
+-o --page_from_origin Load remote page about blockly [default: None]
+
 ## `%cd`
 
 %cd PATH - change current directory of session

--- a/metakernel/magics/blockly_magic.py
+++ b/metakernel/magics/blockly_magic.py
@@ -106,7 +106,7 @@ class BlocklyMagic(Magic):
 
 
 def register_magics(kernel) -> None:
-    kernel.register_magics(Magic)
+    kernel.register_magics(BlocklyMagic)
 
 
 def register_ipython_magics() -> None:

--- a/tests/magics/test_blockly_magic.py
+++ b/tests/magics/test_blockly_magic.py
@@ -1,0 +1,69 @@
+import os
+
+import pytest
+
+from tests.utils import EvalKernel, get_kernel, get_log_text, has_network
+
+
+def test_blockly_default() -> None:
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%blockly")
+    text = get_log_text(kernel)
+    assert "Display Data" in text, text
+
+
+def test_blockly_custom_height() -> None:
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%blockly --height 600")
+    text = get_log_text(kernel)
+    assert "Display Data" in text, text
+
+
+def test_blockly_page_from_local(tmp_path) -> None:
+    html_file = tmp_path / "blockly_page.html"
+    html_file.write_text("<html><body>Blockly</body></html>")
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(f"%blockly --page_from_local {html_file}")
+    text = get_log_text(kernel)
+    assert "Display Data" in text, text
+
+
+@pytest.mark.skipif(not has_network(), reason="no network")
+def test_blockly_page_from_origin() -> None:
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(
+        "%blockly --page_from_origin https://developers-dot-devsite-v2-prod.appspot.com/blockly/blockly-demo/blockly-demo"
+    )
+    text = get_log_text(kernel)
+    assert "Display Data" in text, text
+
+
+def test_blockly_template_data_no_source() -> None:
+    kernel = get_kernel(EvalKernel)
+    magic = kernel.line_magics["blockly"]
+    with pytest.raises(ValueError, match="No -l or -o is provided"):
+        magic.line_blockly(template_data="some_data")
+
+
+def test_blockly_template_data_from_local(tmp_path) -> None:
+    template_html = tmp_path / "template.html"
+    template_html.write_text(
+        "<html>MY_BLOCKLY_TOOLBOX MY_BLOCKLY_WORKSPACE MY_BLOCKLY_BLOCKS_JS</html>"
+    )
+    tdata = str(tmp_path / "tdata")
+    (tmp_path / "tdata-toolbox.xml").write_text("<xml>toolbox</xml>")
+    (tmp_path / "tdata-workspace.xml").write_text("<xml>workspace</xml>")
+    (tmp_path / "tdata-blocks.js").write_text("var blocks = {};")
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(
+        f"%blockly --page_from_local {template_html} --template_data {tdata}"
+    )
+    text = get_log_text(kernel)
+    assert "Display Data" in text, text
+    assert os.path.isfile(tdata + ".html")
+
+
+def test_blockly_help() -> None:
+    kernel = get_kernel()
+    helpstr = kernel.get_help_on("%blockly")
+    assert "blockly" in helpstr.lower(), helpstr


### PR DESCRIPTION
## Summary

- Fix `blockly_magic.py` passing the base `Magic` class instead of `BlocklyMagic` to `register_magics`, which silently prevented the blockly magic from being registered
- Add `tests/magics/test_blockly_magic.py` with 7 tests covering default display, custom height, local/remote page loading, template data generation, error handling, and help text

## Test plan

- [x] `just test tests/magics/test_blockly_magic.py` — all 7 tests pass
- [x] `just test` — full core test suite passes