### PR TITLE
Make pexpect optional and fix Sphinx linkcheck config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -310,3 +310,4 @@ numpydoc_show_class_members = False
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 linkcheck_ignore = [r"http://host\[.*"]
+linkcheck_retries = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -308,3 +308,5 @@ numpydoc_show_class_members = False
 # intersphinx
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+linkcheck_ignore = [r"http://host\[.*"]

--- a/metakernel/__init__.py
+++ b/metakernel/__init__.py
@@ -11,8 +11,6 @@ from ._metakernel import (
 )
 from .magic import Magic, option
 from .parser import Parser
-from .process_metakernel import ProcessMetaKernel
-from .replwrap import REPLWrapper
 
 __all__ = [
     "ExceptionWrapper",
@@ -21,12 +19,18 @@ __all__ = [
     "MetaKernel",
     "MetaKernelApp",
     "Parser",
-    "ProcessMetaKernel",
-    "REPLWrapper",
     "get_metakernel",
     "option",
     "pexpect",
     "register_ipython_magics",
 ]
+
+try:
+    from .process_metakernel import ProcessMetaKernel
+    from .replwrap import REPLWrapper
+
+    __all__ += ["ProcessMetaKernel", "REPLWrapper"]
+except ImportError:
+    pass
 
 __version__ = "0.30.4"

--- a/metakernel/pexpect.py
+++ b/metakernel/pexpect.py
@@ -6,17 +6,26 @@ import shlex
 import signal
 from typing import Any, Optional
 
-from pexpect import EOF, TIMEOUT, is_executable_file  # type:ignore[attr-defined]
-from pexpect import __file__ as PEXPECT_DIR
-
 try:
-    import pty
+    from pexpect import EOF, TIMEOUT, is_executable_file  # type:ignore[attr-defined]
+    from pexpect import __file__ as PEXPECT_DIR
 
-    from pexpect import spawn as pty_spawn
+    try:
+        import pty
+
+        from pexpect import spawn as pty_spawn
+    except ImportError:
+        from pexpect.popen_spawn import PopenSpawn
+
+        pty = None  # type: ignore[assignment]
+
+    pexpect_available = True
 except ImportError:
-    from pexpect.popen_spawn import PopenSpawn
-
+    EOF = None  # type: ignore[assignment]
+    TIMEOUT = None  # type: ignore[assignment]
+    PEXPECT_DIR = None  # type: ignore[assignment]
     pty = None  # type: ignore[assignment]
+    pexpect_available = False
 
 __all__ = ["EOF", "PEXPECT_DIR", "TIMEOUT", "pty", "spawn", "spawnu", "which"]
 
@@ -35,6 +44,10 @@ def spawn(
     encoding: str = "utf-8",
     **kwargs: Any,
 ) -> Any:
+    if not pexpect_available:
+        raise ImportError(
+            "pexpect is required for spawn. Install it with: pip install pexpect"
+        )
     """This is the main entry point for Pexpect. Use this function to start
     and control child applications.
 

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -5,9 +5,8 @@ import sys
 from subprocess import check_output
 from typing import Any
 
-from pexpect import EOF
-
 from . import MetaKernel
+from .pexpect import EOF
 from .replwrap import REPLWrapper, bash
 
 __version__ = "0.0"


### PR DESCRIPTION
## Summary

- Make `pexpect` an optional dependency: wrap imports in `metakernel/pexpect.py`, `metakernel/__init__.py`, and `metakernel/process_metakernel.py` with `try/except` so the package imports cleanly without `pexpect` installed
- Add `linkcheck_ignore` for `http://host[...]` placeholder URLs in Sphinx conf
- Add `linkcheck_retries = 3` to Sphinx conf