### PR TITLE
Add tests for Error_display, do_execute_meta, get_magic_args, display, and process_metakernel classes

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metakernel import MetaKernel
+from metakernel import display as display_module
+from tests.utils import get_kernel
+
+
+@pytest.fixture(autouse=True)
+def reset_meta_kernel():
+    """Restore MetaKernel.meta_kernel to its original value after each test."""
+    original = MetaKernel.meta_kernel
+    yield
+    MetaKernel.meta_kernel = original
+
+
+# --- display() ---
+
+
+def test_display_with_kernel_calls_kernel_Display() -> None:
+    kernel = get_kernel()
+    MetaKernel.meta_kernel = kernel
+    kernel.Display = MagicMock()
+
+    display_module.display("hello")
+
+    kernel.Display.assert_called_once_with("hello")
+
+
+def test_display_with_kernel_passes_kwargs() -> None:
+    kernel = get_kernel()
+    MetaKernel.meta_kernel = kernel
+    kernel.Display = MagicMock()
+
+    display_module.display("hello", clear_output=True)
+
+    kernel.Display.assert_called_once_with("hello", clear_output=True)
+
+
+def test_display_without_kernel_calls_ipdisplay() -> None:
+    MetaKernel.meta_kernel = None
+
+    with patch("metakernel.display.ipdisplay") as mock_ipdisplay:
+        display_module.display("hello")
+        mock_ipdisplay.assert_called_once_with("hello")
+
+
+def test_display_without_kernel_passes_kwargs() -> None:
+    MetaKernel.meta_kernel = None
+
+    with patch("metakernel.display.ipdisplay") as mock_ipdisplay:
+        display_module.display("obj", metadata={"key": "val"})
+        mock_ipdisplay.assert_called_once_with("obj", metadata={"key": "val"})
+
+
+def test_display_without_kernel_multiple_args() -> None:
+    MetaKernel.meta_kernel = None
+
+    with patch("metakernel.display.ipdisplay") as mock_ipdisplay:
+        display_module.display("a", "b", "c")
+        mock_ipdisplay.assert_called_once_with("a", "b", "c")
+
+
+# --- clear_output() ---
+
+
+def test_clear_output_with_kernel_calls_kernel_clear_output() -> None:
+    kernel = get_kernel()
+    MetaKernel.meta_kernel = kernel
+    kernel.clear_output = MagicMock()
+
+    display_module.clear_output()
+
+    kernel.clear_output.assert_called_once_with()
+
+
+def test_clear_output_with_kernel_passes_wait() -> None:
+    kernel = get_kernel()
+    MetaKernel.meta_kernel = kernel
+    kernel.clear_output = MagicMock()
+
+    display_module.clear_output(wait=True)
+
+    kernel.clear_output.assert_called_once_with(wait=True)
+
+
+def test_clear_output_without_kernel_calls_ipclear_output() -> None:
+    MetaKernel.meta_kernel = None
+
+    with patch("metakernel.display.ipclear_output") as mock_clear:
+        display_module.clear_output()
+        mock_clear.assert_called_once_with()
+
+
+def test_clear_output_without_kernel_passes_kwargs() -> None:
+    MetaKernel.meta_kernel = None
+
+    with patch("metakernel.display.ipclear_output") as mock_clear:
+        display_module.clear_output(wait=True)
+        mock_clear.assert_called_once_with(wait=True)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -21,21 +21,23 @@ def reset_meta_kernel():
 def test_display_with_kernel_calls_kernel_Display() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    kernel.Display = MagicMock()
+    mock_display = MagicMock()
+    kernel.Display = mock_display  # type: ignore[method-assign]
 
     display_module.display("hello")
 
-    kernel.Display.assert_called_once_with("hello")
+    mock_display.assert_called_once_with("hello")
 
 
 def test_display_with_kernel_passes_kwargs() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    kernel.Display = MagicMock()
+    mock_display = MagicMock()
+    kernel.Display = mock_display  # type: ignore[method-assign]
 
     display_module.display("hello", clear_output=True)
 
-    kernel.Display.assert_called_once_with("hello", clear_output=True)
+    mock_display.assert_called_once_with("hello", clear_output=True)
 
 
 def test_display_without_kernel_calls_ipdisplay() -> None:
@@ -68,21 +70,23 @@ def test_display_without_kernel_multiple_args() -> None:
 def test_clear_output_with_kernel_calls_kernel_clear_output() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    kernel.clear_output = MagicMock()
+    mock_clear = MagicMock()
+    kernel.clear_output = mock_clear  # type: ignore[method-assign]
 
     display_module.clear_output()
 
-    kernel.clear_output.assert_called_once_with()
+    mock_clear.assert_called_once_with()
 
 
 def test_clear_output_with_kernel_passes_wait() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    kernel.clear_output = MagicMock()
+    mock_clear = MagicMock()
+    kernel.clear_output = mock_clear  # type: ignore[method-assign]
 
     display_module.clear_output(wait=True)
 
-    kernel.clear_output.assert_called_once_with(wait=True)
+    mock_clear.assert_called_once_with(wait=True)
 
 
 def test_clear_output_without_kernel_calls_ipclear_output() -> None:

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import tempfile
+from typing import Any
 
 import pytest
 
@@ -281,7 +282,7 @@ def test_error_display_string() -> None:
 
 def test_error_display_non_string() -> None:
     kernel = get_kernel()
-    display_calls: list = []
+    display_calls: list[Any] = []
     kernel.Display = lambda *args, **kwargs: display_calls.append(args)  # type: ignore[method-assign]
     kernel.Error_display(42)
     # non-string items are routed to Display, not the error message
@@ -293,7 +294,7 @@ def test_error_display_non_string() -> None:
 
 def test_error_display_mixed() -> None:
     kernel = get_kernel()
-    display_calls: list = []
+    display_calls: list[Any] = []
     kernel.Display = lambda *args, **kwargs: display_calls.append(args)  # type: ignore[method-assign]
     kernel.Error_display("oops", 99, "again")
     text = get_log_text(kernel)
@@ -340,7 +341,7 @@ def test_get_magic_args_no_magic() -> None:
 
 def test_get_magic_args_line_magic() -> None:
     kernel = get_kernel()
-    result = kernel.get_magic_args("%cd /tmp")
+    result: Any = kernel.get_magic_args("%cd /tmp")
     assert result is not None
     args, _kwargs, _old_args = result
     assert "/tmp" in args
@@ -348,7 +349,7 @@ def test_get_magic_args_line_magic() -> None:
 
 def test_get_magic_args_no_args_magic() -> None:
     kernel = get_kernel()
-    result = kernel.get_magic_args("%lsmagic")
+    result: Any = kernel.get_magic_args("%lsmagic")
     assert result is not None
     args, kwargs, _old_args = result
     assert args == []

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -272,6 +272,95 @@ def test_misc() -> None:
     assert kernel.do_inspect("hello", 10) is None
 
 
+def test_error_display_string() -> None:
+    kernel = get_kernel()
+    kernel.Error_display("something went wrong")
+    text = get_log_text(kernel)
+    assert "Error: something went wrong" in text
+
+
+def test_error_display_non_string() -> None:
+    kernel = get_kernel()
+    display_calls: list = []
+    kernel.Display = lambda *args, **kwargs: display_calls.append(args)  # type: ignore[method-assign]
+    kernel.Error_display(42)
+    # non-string items are routed to Display, not the error message
+    assert display_calls == [(42,)]
+    text = get_log_text(kernel)
+    # the error message is empty (just a newline)
+    assert "Error: \n" in text
+
+
+def test_error_display_mixed() -> None:
+    kernel = get_kernel()
+    display_calls: list = []
+    kernel.Display = lambda *args, **kwargs: display_calls.append(args)  # type: ignore[method-assign]
+    kernel.Error_display("oops", 99, "again")
+    text = get_log_text(kernel)
+    # string items join into the error message
+    assert "Error: oops again" in text
+    # non-string item goes to Display
+    assert display_calls == [(99,)]
+
+
+def test_error_display_redirect_to_log() -> None:
+    kernel = get_kernel()
+    kernel.redirect_to_log = True
+    kernel.Error_display("logged error message")
+    text = get_log_text(kernel)
+    # info-level log contains the message when redirect_to_log is True
+    assert "logged error message" in text
+    kernel.redirect_to_log = False
+
+
+def test_do_execute_meta_direct() -> None:
+    kernel = get_kernel(EvalKernel)
+    assert kernel.do_execute_meta("reset") == "RESET"
+    assert kernel.do_execute_meta("stop") == "STOP"
+    assert kernel.do_execute_meta("step") == "STEP"
+    assert kernel.do_execute_meta("inspect something") == "INSPECT"
+    with pytest.raises(Exception, match="Unknown meta command"):
+        kernel.do_execute_meta("bogus")
+
+
+def test_do_execute_meta_base_direct() -> None:
+    kernel = get_kernel()
+    for code in ["reset", "stop", "step", "inspect foo"]:
+        with pytest.raises(Exception, match="does not implement this meta command"):
+            kernel.do_execute_meta(code)
+    with pytest.raises(Exception, match="Unknown meta command"):
+        kernel.do_execute_meta("garbage")
+
+
+def test_get_magic_args_no_magic() -> None:
+    kernel = get_kernel()
+    result = kernel.get_magic_args("just plain text")
+    assert result is None
+
+
+def test_get_magic_args_line_magic() -> None:
+    kernel = get_kernel()
+    result = kernel.get_magic_args("%cd /tmp")
+    assert result is not None
+    args, _kwargs, _old_args = result
+    assert "/tmp" in args
+
+
+def test_get_magic_args_no_args_magic() -> None:
+    kernel = get_kernel()
+    result = kernel.get_magic_args("%lsmagic")
+    assert result is not None
+    args, kwargs, _old_args = result
+    assert args == []
+    assert kwargs == {}
+
+
+def test_get_magic_args_unknown_magic() -> None:
+    kernel = get_kernel()
+    result = kernel.get_magic_args("%nonexistent_magic_xyz")
+    assert result is None
+
+
 def teardown() -> None:
     if os.path.exists("TEST.txt"):
         os.remove("TEST.txt")

--- a/tests/test_process_metakernel_classes.py
+++ b/tests/test_process_metakernel_classes.py
@@ -1,0 +1,311 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metakernel import MetaKernel
+from metakernel.process_metakernel import (
+    BashKernel,
+    DynamicKernel,
+    ProcessMetaKernel,
+    TextOutput,
+)
+from tests.utils import get_kernel
+
+
+@pytest.fixture(autouse=True)
+def _restore_process_language_info():
+    """Restore ProcessMetaKernel.language_info after each test.
+
+    DynamicKernel.__init__ mutates the class-level dict in-place, so without
+    this fixture the changes leak across tests.
+    """
+    original = dict(ProcessMetaKernel.language_info)
+    yield
+    ProcessMetaKernel.language_info.clear()
+    ProcessMetaKernel.language_info.update(original)
+
+
+# ---------------------------------------------------------------------------
+# TextOutput
+# ---------------------------------------------------------------------------
+
+
+def test_textoutput_stores_output() -> None:
+    t = TextOutput("some text")
+    assert t.output == "some text"
+
+
+def test_textoutput_repr_returns_output() -> None:
+    t = TextOutput("hello world")
+    assert repr(t) == "hello world"
+
+
+def test_textoutput_repr_not_quoted() -> None:
+    """repr(TextOutput) returns the raw string, unlike Python's repr("...")."""
+    t = TextOutput("hello")
+    assert repr(t) != repr("hello")  # str repr is "'hello'"; TextOutput repr is "hello"
+
+
+# ---------------------------------------------------------------------------
+# ProcessMetaKernel — concrete subclass used across tests
+# ---------------------------------------------------------------------------
+
+
+class _TestKernel(ProcessMetaKernel):
+    _banner = "Test Kernel version 2.5.1"
+
+    def makeWrapper(self) -> MagicMock:  # type: ignore[override]
+        wrapper = MagicMock()
+        wrapper.run_command.return_value = ""
+        return wrapper
+
+
+# ---------------------------------------------------------------------------
+# banner and language_version
+# ---------------------------------------------------------------------------
+
+
+def test_banner_property() -> None:
+    kernel = get_kernel(_TestKernel)
+    assert kernel.banner == "Test Kernel version 2.5.1"
+
+
+def test_language_version_extracted_from_banner() -> None:
+    kernel = get_kernel(_TestKernel)
+    assert kernel.language_version == "2.5.1"
+
+
+def test_language_version_none_when_absent_from_banner() -> None:
+    class _NoBannerKernel(ProcessMetaKernel):
+        _banner = "No version info here"
+
+        def makeWrapper(self) -> None:  # type: ignore[override,return]
+            pass
+
+    kernel = get_kernel(_NoBannerKernel)
+    assert kernel.language_version is None
+
+
+# ---------------------------------------------------------------------------
+# do_execute_direct
+# ---------------------------------------------------------------------------
+
+
+def test_do_execute_direct_returns_none_for_blank_code() -> None:
+    kernel = get_kernel(_TestKernel)
+    assert kernel.do_execute_direct("   ") is None
+
+
+def test_do_execute_direct_blank_code_does_not_call_run_command() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.do_execute_direct("   ")
+    kernel.wrapper.run_command.assert_not_called()
+
+
+def test_do_execute_direct_calls_run_command_with_code() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.do_execute_direct("echo hi")
+    kernel.wrapper.run_command.assert_called_once()
+    args, _ = kernel.wrapper.run_command.call_args
+    assert args[0] == "echo hi"
+
+
+def test_do_execute_direct_strips_trailing_whitespace_from_code() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.do_execute_direct("echo hi\n\n")
+    args, _ = kernel.wrapper.run_command.call_args
+    assert args[0] == "echo hi"
+
+
+def test_do_execute_direct_not_silent_passes_write_as_stream_handler() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.do_execute_direct("ls")
+    _, kwargs = kernel.wrapper.run_command.call_args
+    assert kwargs["stream_handler"] == kernel.Write
+
+
+def test_do_execute_direct_silent_passes_none_as_stream_handler() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.wrapper = MagicMock()
+    kernel.wrapper.run_command.return_value = ""
+    kernel.do_execute_direct("ls", silent=True)
+    _, kwargs = kernel.wrapper.run_command.call_args
+    assert kwargs["stream_handler"] is None
+
+
+def test_do_execute_direct_silent_with_output_returns_textoutput() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.wrapper = MagicMock()
+    kernel.wrapper.run_command.return_value = "result text"
+    result = kernel.do_execute_direct("echo hi", silent=True)
+    assert isinstance(result, TextOutput)
+    assert result.output == "result text"
+
+
+def test_do_execute_direct_silent_with_no_output_returns_none() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.wrapper = MagicMock()
+    kernel.wrapper.run_command.return_value = ""
+    assert kernel.do_execute_direct("echo hi", silent=True) is None
+
+
+# ---------------------------------------------------------------------------
+# check_exitcode
+# ---------------------------------------------------------------------------
+
+
+def test_check_exitcode_returns_zero_and_none() -> None:
+    kernel = get_kernel(_TestKernel)
+    code, trace = kernel.check_exitcode()
+    assert code == 0
+    assert trace is None
+
+
+# ---------------------------------------------------------------------------
+# makeWrapper
+# ---------------------------------------------------------------------------
+
+
+def test_make_wrapper_raises_not_implemented() -> None:
+    class _AbstractKernel(ProcessMetaKernel):
+        pass
+
+    kernel = get_kernel(_AbstractKernel)
+    with pytest.raises(NotImplementedError):
+        kernel.makeWrapper()
+
+
+# ---------------------------------------------------------------------------
+# do_shutdown and restart_kernel
+# ---------------------------------------------------------------------------
+
+
+def test_do_shutdown_calls_terminate_on_wrapper() -> None:
+    kernel = get_kernel(_TestKernel)
+    mock_wrapper = MagicMock()
+    kernel.wrapper = mock_wrapper
+    kernel.do_shutdown(False)
+    mock_wrapper.terminate.assert_called_once()
+
+
+def test_do_shutdown_with_no_wrapper_does_not_raise() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.wrapper = None
+    kernel.do_shutdown(False)  # should not raise
+
+
+def test_restart_kernel_replaces_wrapper() -> None:
+    kernel = get_kernel(_TestKernel)
+    kernel.do_execute_direct("echo hi")  # initialises self.wrapper
+    first_wrapper = kernel.wrapper
+    kernel.restart_kernel()
+    assert kernel.wrapper is not first_wrapper
+
+
+# ---------------------------------------------------------------------------
+# BashKernel
+# ---------------------------------------------------------------------------
+
+_bash_skip = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="BashKernel requires bash/pexpect, not available on Windows",
+)
+
+
+@pytest.fixture()
+def _fresh_bash_banner():
+    """Reset BashKernel._banner so each test fetches it fresh."""
+    original = BashKernel._banner
+    BashKernel._banner = None
+    yield
+    BashKernel._banner = original
+
+
+@_bash_skip
+def test_bash_kernel_banner_contains_bash(_fresh_bash_banner) -> None:
+    kernel = get_kernel(BashKernel)
+    assert "bash" in kernel.banner.lower()
+
+
+@_bash_skip
+def test_bash_kernel_banner_contains_version(_fresh_bash_banner) -> None:
+    kernel = get_kernel(BashKernel)
+    assert "version" in kernel.banner.lower()
+
+
+@_bash_skip
+def test_bash_kernel_language_version_is_not_none(_fresh_bash_banner) -> None:
+    kernel = get_kernel(BashKernel)
+    assert kernel.language_version is not None
+
+
+@_bash_skip
+def test_bash_kernel_banner_is_cached(_fresh_bash_banner) -> None:
+    # BashKernel.banner caches the result on the instance via self._banner
+    kernel = get_kernel(BashKernel)
+    assert kernel._banner is None  # not yet fetched
+    banner1 = kernel.banner
+    assert kernel._banner is not None  # cached on instance after first access
+    banner2 = kernel.banner
+    assert banner1 == banner2
+
+
+# ---------------------------------------------------------------------------
+# DynamicKernel
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_kernel_sets_all_attributes() -> None:
+    with patch.object(MetaKernel, "__init__", return_value=None):
+        k = DynamicKernel(
+            "bash",
+            "bash",
+            mimetype="text/x-bash",
+            implementation="bash_kernel",
+            file_extension="sh",
+            orig_prompt="[$#]",
+            prompt_change="PS1='{0}'",
+            extra_init_cmd="export PAGER=cat",
+        )
+    assert k.executable == "bash"
+    assert k.language == "bash"
+    assert k.implementation == "bash_kernel"
+    assert k.orig_prompt == "[$#]"
+    assert k.prompt_change == "PS1='{0}'"
+    assert k.prompt_cmd is None
+    assert k.extra_init_cmd == "export PAGER=cat"
+    assert k.stdin_prompt_regex is None
+    assert k.language_info["mimetype"] == "text/x-bash"
+    assert k.language_info["language"] == "bash"
+    assert k.language_info["file_extension"] == "sh"
+
+
+def test_dynamic_kernel_default_attributes() -> None:
+    with patch.object(MetaKernel, "__init__", return_value=None):
+        k = DynamicKernel("python", "python")
+    assert k.implementation == "metakernel"
+    assert k.language_info["mimetype"] == "text/plain"
+    assert k.language_info["file_extension"] == "txt"
+
+
+def test_dynamic_kernel_make_wrapper_passes_correct_args() -> None:
+    with (
+        patch.object(MetaKernel, "__init__", return_value=None),
+        patch("metakernel.process_metakernel.REPLWrapper") as mock_repl,
+    ):
+        k = DynamicKernel(
+            "bash",
+            "bash",
+            orig_prompt="[$#]",
+            prompt_change="PS1='{0}' PS2='{1}'",
+        )
+        k.makeWrapper()
+    mock_repl.assert_called_once_with(
+        "bash",
+        "[$#]",
+        "PS1='{0}' PS2='{1}'",
+        prompt_emit_cmd=None,
+        stdin_prompt_regex=None,
+        extra_init_cmd=None,
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar, overload
 
 from metakernel import MetaKernel
+
+_KT = TypeVar("_KT", bound=MetaKernel)
 
 try:
     from jupyter_client import session as ss
@@ -88,7 +90,15 @@ def get_log() -> Logger:
     return log
 
 
-def get_kernel(kernel_class=MetaKernel) -> MetaKernel:
+@overload
+def get_kernel() -> MetaKernel: ...
+
+
+@overload
+def get_kernel(kernel_class: type[_KT]) -> _KT: ...
+
+
+def get_kernel(kernel_class: type[MetaKernel] = MetaKernel) -> MetaKernel:
     import weakref
 
     context = zmq.Context.instance()
@@ -98,7 +108,7 @@ def get_kernel(kernel_class=MetaKernel) -> MetaKernel:
         session=ss.Session(), iopub_socket=iopub_socket, log=get_log()
     )
     weakref.finalize(kernel, iopub_socket.close)
-    return kernel  # type:ignore[no-any-return]
+    return kernel
 
 
 def clear_log_text(obj: Any) -> None:


### PR DESCRIPTION
## Summary

- **`test_metakernel.py`**: direct unit tests for `Error_display` (string, non-string, mixed args, `redirect_to_log`), `do_execute_meta` (both `EvalKernel` and base `MetaKernel`), and `get_magic_args` (no magic, line magic, no-args magic, unknown magic)
- **`test_display.py`**: new module testing `display.display()` and `display.clear_output()` with and without an active `MetaKernel` instance, verifying correct delegation to either `kernel.Display`/`kernel.clear_output` or the IPython fallbacks
- **`test_process_metakernel_classes.py`**: new module covering all classes in `process_metakernel.py` — `TextOutput`, `ProcessMetaKernel` (banner, `language_version`, `do_execute_direct` all code paths, `check_exitcode`, `makeWrapper`, `do_shutdown`, `restart_kernel`), `BashKernel` (banner content and instance-level caching), and `DynamicKernel` (attribute initialisation and `makeWrapper` argument forwarding)

## Test plan

- [x] All new tests pass locally (`just test`)
- [x] Linting passes (`ruff format` / `ruff check`)
- [x] Pre-commit hooks pass