### PR TITLE
Add tests for Activity class methods and ParallelMagic methods

### DIFF
--- a/tests/magics/test_activity_magic.py
+++ b/tests/magics/test_activity_magic.py
@@ -352,6 +352,7 @@ def test_handle_submit_writes_choice_to_results_file(tmp_path) -> None:
     a = Activity()
     a.load(str(activity_file))
     a.handle_submit(MockSender("1"))
+    assert a.results_filename is not None
     with open(a.results_filename) as f:
         results = f.read()
     assert "::1\n" in results
@@ -366,6 +367,7 @@ def test_handle_submit_records_question_id(tmp_path) -> None:
     a.load(str(activity_file))
     a.set_id("q1")
     a.handle_submit(MockSender("2"))
+    assert a.results_filename is not None
     with open(a.results_filename) as f:
         results = f.read()
     assert results.startswith("q1::")
@@ -429,6 +431,7 @@ def test_handle_results_runs_without_error(tmp_path) -> None:
     activity_file.write_text(ACTIVITY_TEXT)
     a = Activity()
     a.load(str(activity_file))
+    assert a.results_filename is not None
     with open(a.results_filename, "w") as f:
         f.write("q1::user1::2024-01-01::1\n")
         f.write("q1::user2::2024-01-01::2\n")

--- a/tests/magics/test_activity_magic.py
+++ b/tests/magics/test_activity_magic.py
@@ -12,6 +12,7 @@ from metakernel.magics.activity_magic import Activity, touch
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 NO_WIDGETS = importlib.util.find_spec("ipywidgets") is None
+NO_PORTALOCKER = importlib.util.find_spec("portalocker") is None
 
 # Minimal poll activity as a Python literal (load_json uses eval, not json.loads)
 ACTIVITY_TEXT = """\
@@ -28,6 +29,33 @@ ACTIVITY_TEXT = """\
     ]
 }
 """
+
+# Multi-question activity for navigation tests
+ACTIVITY_TEXT_MULTI = """\
+{
+    "activity": "poll",
+    "instructors": ["teacher01"],
+    "items": [
+        {
+            "id": "q1",
+            "type": "multiple choice",
+            "question": "Question one?",
+            "options": ["Yes", "No"]
+        },
+        {
+            "id": "q2",
+            "type": "multiple choice",
+            "question": "Question two?",
+            "options": ["A", "B", "C"]
+        }
+    ]
+}
+"""
+
+
+class MockSender:
+    def __init__(self, description: str) -> None:
+        self.description = description
 
 
 # ---------------------------------------------------------------------------
@@ -198,3 +226,258 @@ def test_line_activity_magic_renders_widget(tmp_path) -> None:
 
     assert "Display Widget" in get_log_text(kernel)
     assert os.path.exists(str(activity_file) + ".results")
+
+
+# ---------------------------------------------------------------------------
+# Activity.create_widget()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_create_widget_creates_five_choice_slots() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT)
+    assert len(a.buttons) == 5
+    assert len(a.choice_widgets) == 5
+    assert len(a.choice_row_list) == 5
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_create_widget_creates_navigation_buttons() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT)
+    assert hasattr(a, "next_button")
+    assert hasattr(a, "prev_button")
+    assert hasattr(a, "results_button")
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_create_widget_creates_top_level_output_and_stack() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT)
+    assert hasattr(a, "top_level")
+    assert hasattr(a, "output")
+    assert hasattr(a, "stack")
+
+
+# ---------------------------------------------------------------------------
+# Activity.set_question()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_set_question_updates_widget_value() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT)
+    a.set_question("New question?")
+    assert a.question_widget.value == "<h1>New question?</h1>"
+
+
+# ---------------------------------------------------------------------------
+# Activity.set_id()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_set_id_updates_widget_and_attribute() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT)
+    a.set_id("q99")
+    assert a.id_widget.value == "<p><b>Question ID</b>: q99</p>"
+    assert a.id == "q99"
+
+
+# ---------------------------------------------------------------------------
+# Activity.use_question()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_use_question_first_question_disables_prev_button() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.use_question(0)
+    assert a.prev_button.disabled is True
+    assert a.next_button.disabled is False
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_use_question_last_question_disables_next_button() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.use_question(1)
+    assert a.prev_button.disabled is False
+    assert a.next_button.disabled is True
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_use_question_sets_question_text() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.use_question(1)
+    assert "Question two?" in a.question_widget.value
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_use_question_hides_unused_choice_rows() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.use_question(0)  # 2 options; rows 2-4 should be hidden
+    assert a.choice_row_list[0].layout.visibility == "visible"
+    assert a.choice_row_list[1].layout.visibility == "visible"
+    assert a.choice_row_list[2].layout.visibility == "hidden"
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_use_question_shows_correct_number_of_choice_rows() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.use_question(1)  # 3 options
+    assert a.choice_row_list[0].layout.visibility == "visible"
+    assert a.choice_row_list[1].layout.visibility == "visible"
+    assert a.choice_row_list[2].layout.visibility == "visible"
+    assert a.choice_row_list[3].layout.visibility == "hidden"
+
+
+# ---------------------------------------------------------------------------
+# Activity.handle_submit()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+@pytest.mark.skipif(NO_PORTALOCKER, reason="Requires portalocker")
+def test_handle_submit_writes_choice_to_results_file(tmp_path) -> None:
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+    a.handle_submit(MockSender("1"))
+    with open(a.results_filename) as f:
+        results = f.read()
+    assert "::1\n" in results
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+@pytest.mark.skipif(NO_PORTALOCKER, reason="Requires portalocker")
+def test_handle_submit_records_question_id(tmp_path) -> None:
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+    a.set_id("q1")
+    a.handle_submit(MockSender("2"))
+    with open(a.results_filename) as f:
+        results = f.read()
+    assert results.startswith("q1::")
+
+
+# ---------------------------------------------------------------------------
+# Activity.handle_next()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_handle_next_increments_index() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    assert a.index == 0
+    a.handle_next(MockSender("Next"))
+    assert a.index == 1
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_handle_next_does_not_exceed_last_question() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.handle_next(MockSender("Next"))
+    a.handle_next(MockSender("Next"))  # already at last question
+    assert a.index == 1
+
+
+# ---------------------------------------------------------------------------
+# Activity.handle_prev()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_handle_prev_decrements_index() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.handle_next(MockSender("Next"))
+    assert a.index == 1
+    a.handle_prev(MockSender("Previous"))
+    assert a.index == 0
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_handle_prev_does_not_go_below_zero() -> None:
+    a = Activity()
+    a.load_json(ACTIVITY_TEXT_MULTI)
+    a.handle_prev(MockSender("Previous"))  # already at index 0
+    assert a.index == 0
+
+
+# ---------------------------------------------------------------------------
+# Activity.handle_results()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+@pytest.mark.skipif(NO_PORTALOCKER, reason="Requires portalocker")
+def test_handle_results_runs_without_error(tmp_path) -> None:
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+    with open(a.results_filename, "w") as f:
+        f.write("q1::user1::2024-01-01::1\n")
+        f.write("q1::user2::2024-01-01::2\n")
+    a.handle_results(MockSender("Results"))
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+@pytest.mark.skipif(NO_PORTALOCKER, reason="Requires portalocker")
+def test_handle_results_sets_last_id(tmp_path) -> None:
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+    assert a.last_id is None
+    a.handle_results(MockSender("Results"))
+    assert a.last_id == "q1"
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+@pytest.mark.skipif(NO_PORTALOCKER, reason="Requires portalocker")
+def test_handle_results_toggles_show_initial_on_repeat(tmp_path) -> None:
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+    assert a.show_initial is True
+    a.handle_results(MockSender("Results"))
+    assert a.show_initial is True  # first call sets last_id, does not toggle
+    a.handle_results(MockSender("Results"))
+    assert a.show_initial is False  # second call on same id toggles
+
+
+# ---------------------------------------------------------------------------
+# Activity.render()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_WIDGETS, reason="Requires ipywidgets")
+def test_render_calls_display_with_top_level(tmp_path, monkeypatch) -> None:
+    import metakernel.display as display_mod
+
+    activity_file = tmp_path / "activity.poll"
+    activity_file.write_text(ACTIVITY_TEXT)
+    a = Activity()
+    a.load(str(activity_file))
+
+    displayed = []
+    monkeypatch.setattr(display_mod, "display", lambda obj: displayed.append(obj))
+    a.render()
+
+    assert len(displayed) == 1
+    assert displayed[0] is a.top_level

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -337,9 +337,9 @@ def test_line_px_exception_stores_error_string() -> None:
 
 
 def test_line_px_retry_true_succeeds_clears_retry_flag(monkeypatch) -> None:
-    import metakernel.magics.parallel_magic as pmod
+    import time
 
-    monkeypatch.setattr(pmod.time, "sleep", lambda _: None)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
     magic = _make_px_magic(view=_PxView(return_value="ok"))
     magic.retry = True
     magic.line_px("x")
@@ -348,9 +348,9 @@ def test_line_px_retry_true_succeeds_clears_retry_flag(monkeypatch) -> None:
 
 
 def test_line_px_retry_true_all_fail_raises(monkeypatch) -> None:
-    import metakernel.magics.parallel_magic as pmod
+    import time
 
-    monkeypatch.setattr(pmod.time, "sleep", lambda _: None)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
     magic = _make_px_magic(view=_PxView(raises=RuntimeError("dead")))
     magic.retry = True
     with pytest.raises(Exception, match="Cluster clients have not started"):

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     ipyparallel = None
 
+NO_IPYPARALLEL = ipyparallel is None
+
 
 @pytest.mark.skipif(ipyparallel is None, reason="Requires ipyparallel")
 @pytest.mark.skipif(sys.platform == "darwin", reason="Fails on darwin")
@@ -32,3 +34,523 @@ def test_parallel_magic() -> None:
 # def teardown():
 #    ## shutdown the cluster:
 #    os.system("ipcluster stop")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking the cluster
+# ---------------------------------------------------------------------------
+
+
+class MockView:
+    """Minimal stand-in for an ipyparallel view."""
+
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, code, block=False):
+        self.executed.append(code)
+
+    def __getitem__(self, key):
+        return None
+
+    def __setitem__(self, key, value):
+        pass
+
+    def scatter(self, name, values, flatten=False):
+        pass
+
+    def append(self, other):
+        pass
+
+
+class MockClient:
+    """Stand-in for ipyparallel.Client that records how views were requested."""
+
+    def __init__(self):
+        self.ids = [0, 1, 2]
+        self.accessed_with = []
+
+    def __getitem__(self, item):
+        self.accessed_with.append(item)
+        return MockView()
+
+    def load_balanced_view(self):
+        return MockView()
+
+    def __len__(self):
+        return len(self.ids)
+
+
+# ---------------------------------------------------------------------------
+# line_parallel with ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_no_ids_uses_all_engines(monkeypatch) -> None:
+    """ids=None selects all engines via client[:]."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass")
+
+    assert magic.view is not None
+    assert slice(None, None, None) in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_single_int(monkeypatch) -> None:
+    """ids=[0] resolves to int 0 and selects engine 0 via client[0]."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", ids="[0]")
+
+    assert magic.view is not None
+    assert 0 in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_slice(monkeypatch) -> None:
+    """ids=[0:2] resolves to slice(0, 2) and selects engines 0-1 via client[slice]."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", ids="[0:2]")
+
+    assert magic.view is not None
+    assert slice(0, 2, None) in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_slice_all(monkeypatch) -> None:
+    """ids=[:] resolves to slice(None) and selects all engines via client[:]."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", ids="[:]")
+
+    assert magic.view is not None
+    assert slice(None, None, None) in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_tuple_indexes(monkeypatch) -> None:
+    """ids=[0,2] resolves to a tuple and calls client[item] for each element."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", ids="[0,2]")
+
+    assert magic.view is not None
+    assert 0 in client.accessed_with
+    assert 2 in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_invalid_falls_back_to_all(monkeypatch) -> None:
+    """An ids value that fails eval falls back to client[:] (all engines)."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", ids="[[[invalid")
+
+    assert magic.view is not None
+    assert slice(None, None, None) in client.accessed_with
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_stores_module_class_kernel_name(monkeypatch) -> None:
+    """line_parallel stores module_name, class_name, and kernel_name on the magic."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    magic = ParallelMagic(get_kernel(EvalKernel))
+    magic.line_parallel("mymod", "MyClass", kernel_name="mykernel")
+
+    assert magic.module_name == "mymod"
+    assert magic.class_name == "MyClass"
+    assert magic.kernel_name == "mykernel"
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_parallel_ids_sets_cluster_variables_on_kernel(monkeypatch) -> None:
+    """line_parallel sets cluster_size and cluster_rank=-1 on the host kernel."""
+    client = MockClient()
+    monkeypatch.setattr(ipyparallel, "Client", lambda: client)
+
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    kernel = get_kernel(EvalKernel)
+    magic = ParallelMagic(kernel)
+    magic.line_parallel("mymod", "MyClass")
+
+    assert kernel.get_variable("cluster_size") == len(client.ids)
+    assert kernel.get_variable("cluster_rank") == -1
+
+
+# ---------------------------------------------------------------------------
+# Helpers for line_px / _clean_code tests
+# ---------------------------------------------------------------------------
+
+
+class _PxView:
+    """MockView whose __getitem__ can return a value or raise an exception."""
+
+    def __init__(self, return_value=None, raises=None, fail_times=0):
+        self.called_with = []
+        self._return_value = return_value
+        self._raises = raises
+        self._fail_times = fail_times  # raise on first N calls, then succeed
+        self._call_count = 0
+
+    def __getitem__(self, key):
+        self._call_count += 1
+        self.called_with.append(key)
+        if self._raises is not None:
+            if self._fail_times == 0 or self._call_count <= self._fail_times:
+                raise self._raises
+        return self._return_value
+
+    def __setitem__(self, key, value):
+        pass
+
+    def execute(self, code, block=False):
+        pass
+
+    def scatter(self, name, values, flatten=False):
+        pass
+
+
+def _make_px_magic(view=None, kernel_name="default"):
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    kernel = get_kernel(EvalKernel)
+    magic = ParallelMagic(kernel)
+    magic.view = view if view is not None else _PxView()
+    magic.kernel_name = kernel_name
+    return magic
+
+
+# ---------------------------------------------------------------------------
+# _clean_code
+# ---------------------------------------------------------------------------
+
+
+def test_clean_code_strips_whitespace() -> None:
+    magic = _make_px_magic()
+    assert magic._clean_code("  hello  ") == "hello"
+
+
+def test_clean_code_escapes_double_quotes() -> None:
+    magic = _make_px_magic()
+    assert magic._clean_code('say "hi"') == 'say \\"hi\\"'
+
+
+def test_clean_code_escapes_newlines() -> None:
+    magic = _make_px_magic()
+    assert magic._clean_code("a\nb") == "a\\nb"
+
+
+def test_clean_code_combined() -> None:
+    magic = _make_px_magic()
+    assert magic._clean_code('  "a"\n"b"  ') == '\\"a\\"\\n\\"b\\"'
+
+
+# ---------------------------------------------------------------------------
+# line_px
+# ---------------------------------------------------------------------------
+
+
+def test_line_px_stores_result_in_retval() -> None:
+    magic = _make_px_magic(view=_PxView(return_value=[0, 1, 2]))
+    magic.line_px("cluster_rank")
+    assert magic.retval == [0, 1, 2]
+
+
+def test_line_px_uses_magic_kernel_name_by_default() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view, kernel_name="mykernel")
+    magic.line_px("x")
+    assert "mykernel" in view.called_with[0]
+
+
+def test_line_px_overrides_kernel_name_when_provided() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view, kernel_name="default")
+    magic.line_px("x", kernel_name="scheme")
+    assert "scheme" in view.called_with[0]
+    assert "default" not in view.called_with[0]
+
+
+def test_line_px_expression_appears_in_view_call() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view)
+    magic.line_px("1 + 1")
+    assert "1 + 1" in view.called_with[0]
+
+
+def test_line_px_set_variable_stores_result_on_kernel() -> None:
+    magic = _make_px_magic(view=_PxView(return_value=42))
+    magic.line_px("x", set_variable="myvar")
+    assert magic.kernel.get_variable("myvar") == 42
+    assert magic.retval is None
+
+
+def test_line_px_evaluate_true_sets_code() -> None:
+    magic = _make_px_magic()
+    magic.line_px("my_expression", evaluate=True)
+    assert magic.code == "my_expression"
+
+
+def test_line_px_evaluate_false_leaves_code_unchanged() -> None:
+    magic = _make_px_magic()
+    magic.code = "original"
+    magic.line_px("new_expression", evaluate=False)
+    assert magic.code == "original"
+
+
+def test_line_px_exception_stores_error_string() -> None:
+    magic = _make_px_magic(view=_PxView(raises=RuntimeError("engine down")))
+    magic.line_px("x")
+    assert "engine down" in magic.retval
+
+
+def test_line_px_retry_true_succeeds_clears_retry_flag(monkeypatch) -> None:
+    import metakernel.magics.parallel_magic as pmod
+
+    monkeypatch.setattr(pmod.time, "sleep", lambda _: None)
+    magic = _make_px_magic(view=_PxView(return_value="ok"))
+    magic.retry = True
+    magic.line_px("x")
+    assert magic.retval == "ok"
+    assert magic.retry is False
+
+
+def test_line_px_retry_true_all_fail_raises(monkeypatch) -> None:
+    import metakernel.magics.parallel_magic as pmod
+
+    monkeypatch.setattr(pmod.time, "sleep", lambda _: None)
+    magic = _make_px_magic(view=_PxView(raises=RuntimeError("dead")))
+    magic.retry = True
+    with pytest.raises(Exception, match="Cluster clients have not started"):
+        magic.line_px("x")
+
+
+# ---------------------------------------------------------------------------
+# cell_px
+# ---------------------------------------------------------------------------
+
+
+def test_cell_px_stores_result_in_retval() -> None:
+    magic = _make_px_magic(view=_PxView(return_value=[0, 1, 2]))
+    magic.code = "cluster_rank"
+    magic.cell_px()
+    assert magic.retval == [0, 1, 2]
+
+
+def test_cell_px_uses_magic_kernel_name_by_default() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view, kernel_name="mykernel")
+    magic.code = "x"
+    magic.cell_px()
+    assert "mykernel" in view.called_with[0]
+
+
+def test_cell_px_overrides_kernel_name_when_provided() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view, kernel_name="default")
+    magic.code = "x"
+    magic.cell_px(kernel_name="scheme")
+    assert "scheme" in view.called_with[0]
+    assert "default" not in view.called_with[0]
+
+
+def test_cell_px_code_appears_in_view_call() -> None:
+    view = _PxView()
+    magic = _make_px_magic(view=view)
+    magic.code = "1 + 1"
+    magic.cell_px()
+    assert "1 + 1" in view.called_with[0]
+
+
+def test_cell_px_set_variable_stores_result_on_kernel() -> None:
+    magic = _make_px_magic(view=_PxView(return_value=99))
+    magic.code = "x"
+    magic.cell_px(set_variable="myvar")
+    assert magic.kernel.get_variable("myvar") == 99
+    assert magic.retval is None
+
+
+def test_cell_px_evaluate_true_sets_evaluate_flag() -> None:
+    magic = _make_px_magic()
+    magic.code = "x"
+    magic.cell_px(evaluate=True)
+    assert magic.evaluate is True
+
+
+def test_cell_px_evaluate_false_sets_evaluate_flag() -> None:
+    magic = _make_px_magic()
+    magic.code = "x"
+    magic.evaluate = True  # pre-set to confirm it gets overwritten
+    magic.cell_px(evaluate=False)
+    assert magic.evaluate is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for line_pmap tests
+# ---------------------------------------------------------------------------
+
+
+class _LoadBalancedView:
+    """Mock for an ipyparallel load-balanced view."""
+
+    def __init__(self, return_value=None):
+        self.map_async_calls = []
+        self._return_value = return_value
+
+    def map_async(self, f, args):
+        self.map_async_calls.append((f, list(args)))
+        return self._return_value
+
+
+def _make_pmap_magic(lb_view=None, kernel_name="default"):
+    from metakernel.magics.parallel_magic import ParallelMagic
+
+    kernel = get_kernel(EvalKernel)
+    magic = ParallelMagic(kernel)
+    magic.view_load_balanced = lb_view if lb_view is not None else _LoadBalancedView()
+    magic.kernel_name = kernel_name
+    return magic
+
+
+# ---------------------------------------------------------------------------
+# line_pmap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_stores_result_in_retval() -> None:
+    lb_view = _LoadBalancedView(return_value="async_result")
+    magic = _make_pmap_magic(lb_view=lb_view)
+    magic.line_pmap("myfunc", "[1, 2, 3]")
+    assert magic.retval == "async_result"
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_evaluates_args_list() -> None:
+    lb_view = _LoadBalancedView()
+    magic = _make_pmap_magic(lb_view=lb_view)
+    magic.line_pmap("myfunc", "[10, 20, 30]")
+    _, mapped_args = lb_view.map_async_calls[0]
+    assert mapped_args == [10, 20, 30]
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_evaluates_args_range() -> None:
+    lb_view = _LoadBalancedView()
+    magic = _make_pmap_magic(lb_view=lb_view)
+    magic.line_pmap("myfunc", "range(3)")
+    _, mapped_args = lb_view.map_async_calls[0]
+    assert mapped_args == [0, 1, 2]
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_uses_magic_kernel_name_by_default() -> None:
+    lb_view = _LoadBalancedView()
+    magic = _make_pmap_magic(lb_view=lb_view, kernel_name="mykernel")
+    magic.line_pmap("myfunc", "[]")
+    f, _ = lb_view.map_async_calls[0]
+    assert f.__defaults__[0] == "mykernel"
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_overrides_kernel_name_when_provided() -> None:
+    lb_view = _LoadBalancedView()
+    magic = _make_pmap_magic(lb_view=lb_view, kernel_name="default")
+    magic.line_pmap("myfunc", "[]", kernel_name="scheme")
+    f, _ = lb_view.map_async_calls[0]
+    assert f.__defaults__[0] == "scheme"
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_function_name_captured_in_lambda() -> None:
+    lb_view = _LoadBalancedView()
+    magic = _make_pmap_magic(lb_view=lb_view)
+    magic.line_pmap("my_special_func", "[]")
+    f, _ = lb_view.map_async_calls[0]
+    assert f.__defaults__[1] == "my_special_func"
+
+
+@pytest.mark.skipif(NO_IPYPARALLEL, reason="Requires ipyparallel")
+def test_line_pmap_set_variable_stores_result_on_kernel() -> None:
+    lb_view = _LoadBalancedView(return_value="result")
+    magic = _make_pmap_magic(lb_view=lb_view)
+    magic.line_pmap("myfunc", "[1]", set_variable="myvar")
+    assert magic.kernel.get_variable("myvar") == "result"
+    assert magic.retval is None
+
+
+# ---------------------------------------------------------------------------
+# post_process
+# ---------------------------------------------------------------------------
+
+
+def test_post_process_returns_retval_for_nonempty_truthy_list() -> None:
+    magic = _make_pmap_magic()
+    magic.retval = [1, 2, 3]
+    assert magic.post_process(None) == [1, 2, 3]
+
+
+def test_post_process_returns_none_for_all_falsy_list() -> None:
+    magic = _make_pmap_magic()
+    magic.retval = [0, None, False]
+    assert magic.post_process(None) is None
+
+
+def test_post_process_returns_none_for_empty_list() -> None:
+    magic = _make_pmap_magic()
+    magic.retval = []
+    assert magic.post_process(None) is None
+
+
+def test_post_process_returns_retval_for_non_list() -> None:
+    magic = _make_pmap_magic()
+    magic.retval = "result"
+    assert magic.post_process(None) == "result"
+
+
+def test_post_process_ignores_retval_argument() -> None:
+    magic = _make_pmap_magic()
+    magic.retval = "from_self"
+    assert magic.post_process("ignored_argument") == "from_self"
+
+
+def test_post_process_returns_retval_when_any_raises() -> None:
+    class _Ambiguous:
+        def __bool__(self):
+            raise ValueError("ambiguous truth value")
+
+    magic = _make_pmap_magic()
+    magic.retval = [_Ambiguous()]
+    assert magic.post_process(None) is magic.retval


### PR DESCRIPTION
## Summary

- Extends `test_activity_magic.py` with tests for all `Activity` class methods: `create_widget`, `set_question`, `set_id`, `use_question`, `handle_submit`, `handle_next`, `handle_prev`, `handle_results`, and `render`
- Extends `test_parallel_magic.py` with tests for `ParallelMagic.line_parallel` (ids routing), `line_px`, `cell_px`, `line_pmap`, `post_process`, and `_clean_code`
- All cluster-dependent tests use lightweight mocks (`MockClient`, `MockView`, `_PxView`, `_LoadBalancedView`) so no live ipcluster is required

## Test plan

- [x] `just test tests/magics/test_activity_magic.py` — all tests pass
- [x] `just test tests/magics/test_parallel_magic.py` — all tests pass