### PR TITLE
Add tests for include, install, kernel, and macro magics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 exclude = [
     "hatch_build.*\\.py",
+    "metakernel_echo/.*"
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/magics/test_include_magic.py
+++ b/tests/magics/test_include_magic.py
@@ -1,4 +1,6 @@
-from tests.utils import get_kernel
+import os
+
+from tests.utils import get_kernel, get_log_text
 
 EXECUTION = ""
 
@@ -28,3 +30,96 @@ def test_include_magic() -> None:
     kernel.do_execute("%%include '%s' '%s'" % (FILE, FILE))
     assert "metakernel" in EXECUTION
     assert ("AND " + "THIS") not in EXECUTION
+
+
+def test_line_include_single_file(tmp_path) -> None:
+    """Test %include (line magic) with a single file."""
+    kernel = get_kernel()
+    executed = []
+
+    def do_execute_direct(code):
+        executed.append(code)
+
+    kernel.do_execute_direct = do_execute_direct  # type: ignore[method-assign,assignment]
+
+    f = tmp_path / "snippet.py"
+    f.write_text("x = 42\n")
+
+    kernel.do_execute(f"%include {f}")
+    assert executed, "do_execute_direct was never called"
+    assert "x = 42" in executed[-1]
+
+
+def test_line_include_with_trailing_code(tmp_path) -> None:
+    """Test %include inserts file content before subsequent code lines."""
+    kernel = get_kernel()
+    executed = []
+
+    def do_execute_direct(code):
+        executed.append(code)
+
+    kernel.do_execute_direct = do_execute_direct  # type: ignore[method-assign,assignment]
+
+    f = tmp_path / "snippet.py"
+    f.write_text("y = 10\n")
+
+    kernel.do_execute(f"%include {f}\nz = 20")
+    assert executed
+    result = executed[-1]
+    assert "y = 10" in result
+    assert "z = 20" in result
+
+
+def test_line_include_multiple_files(tmp_path) -> None:
+    """Test %include with multiple space-separated filenames."""
+    kernel = get_kernel()
+    executed = []
+
+    def do_execute_direct(code):
+        executed.append(code)
+
+    kernel.do_execute_direct = do_execute_direct  # type: ignore[method-assign,assignment]
+
+    f1 = tmp_path / "a.py"
+    f1.write_text("a = 1\n")
+    f2 = tmp_path / "b.py"
+    f2.write_text("b = 2\n")
+
+    kernel.do_execute(f"%include {f1} {f2}")
+    assert executed
+    result = executed[-1]
+    assert "a = 1" in result
+    assert "b = 2" in result
+
+
+def test_line_include_tilde_expansion(tmp_path, monkeypatch) -> None:
+    """Test that ~ in filename is expanded to the home directory."""
+    kernel = get_kernel()
+    executed = []
+
+    def do_execute_direct(code):
+        executed.append(code)
+
+    kernel.do_execute_direct = do_execute_direct  # type: ignore[method-assign,assignment]
+
+    f = tmp_path / "home_snippet.py"
+    f.write_text("home_var = True\n")
+
+    original_expanduser = os.path.expanduser
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(f) if p == "~/home_snippet.py" else original_expanduser(p),
+    )
+
+    kernel.do_execute("%include ~/home_snippet.py")
+    assert executed
+    assert "home_var = True" in executed[-1]
+
+
+def test_line_include_file_not_found() -> None:
+    """Test that including a nonexistent file logs an error."""
+    kernel = get_kernel()
+    kernel.do_execute("%include /nonexistent_path_xyz_abc/file.py")
+    log_text = get_log_text(kernel)
+    assert "Error" in log_text

--- a/tests/magics/test_install_magic.py
+++ b/tests/magics/test_install_magic.py
@@ -1,0 +1,168 @@
+import os
+import sys
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="install_magic path assertions use POSIX separators",
+    ),
+    # install_magic.py uses open() without a context manager; suppress the
+    # resulting ResourceWarning so tests are not failed by a pre-existing issue
+    # in the code under test.
+    pytest.mark.filterwarnings("ignore::ResourceWarning"),
+]
+
+from tests.utils import get_kernel
+
+_CUSTOM_JS_TILDE = "~/.ipython/profile_default/static/custom/custom.js"
+
+
+def _setup(tmp_path, monkeypatch, initial_content=""):
+    """Return (kernel, custom_js_path, inner_calls).
+
+    The kernel's do_execute is wrapped so that any !-prefixed (shell) call is
+    captured in *inner_calls* rather than actually executed.  expanduser is
+    patched to redirect the custom.js path to a temp file.
+    """
+    custom_js = tmp_path / "custom.js"
+    custom_js.write_text(initial_content)
+
+    original_expanduser = os.path.expanduser
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(custom_js) if p == _CUSTOM_JS_TILDE else original_expanduser(p),
+    )
+
+    kernel = get_kernel()
+    inner_calls: list[str] = []
+    original_do_execute = kernel.do_execute
+
+    def capturing_do_execute(code, *args, **kwargs):
+        if code.startswith("!"):
+            inner_calls.append(code)
+            return {
+                "status": "ok",
+                "execution_count": 0,
+                "payload": [],
+                "user_expressions": {},
+            }
+        return original_do_execute(code, *args, **kwargs)
+
+    kernel.do_execute = capturing_do_execute
+    return kernel, custom_js, inner_calls
+
+
+# ---------------------------------------------------------------------------
+# line_install branches: known packages each dispatch a specific shell command
+# ---------------------------------------------------------------------------
+
+
+def test_line_install_calico_publish(tmp_path, monkeypatch) -> None:
+    """calico-publish dispatches the correct ipython install-nbextension URL."""
+    kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
+
+    kernel.do_execute("%install calico-publish")
+
+    assert len(inner_calls) == 1
+    assert "ipython install-nbextension" in inner_calls[0]
+    assert "calico-publish.js" in inner_calls[0]
+
+
+def test_line_install_calico_spell_check(tmp_path, monkeypatch) -> None:
+    """calico-spell-check dispatches the correct ipython install-nbextension URL."""
+    kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
+
+    kernel.do_execute("%install calico-spell-check")
+
+    assert len(inner_calls) == 1
+    assert "ipython install-nbextension" in inner_calls[0]
+    assert "calico-spell-check-1.0.zip" in inner_calls[0]
+
+
+def test_line_install_calico_cell_tools(tmp_path, monkeypatch) -> None:
+    """calico-cell-tools dispatches the correct ipython install-nbextension URL."""
+    kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
+
+    kernel.do_execute("%install calico-cell-tools")
+
+    assert len(inner_calls) == 1
+    assert "ipython install-nbextension" in inner_calls[0]
+    assert "calico-cell-tools-1.0.zip" in inner_calls[0]
+
+
+def test_line_install_calico_document_tools(tmp_path, monkeypatch) -> None:
+    """calico-document-tools dispatches the correct ipython install-nbextension URL."""
+    kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
+
+    kernel.do_execute("%install calico-document-tools")
+
+    assert len(inner_calls) == 1
+    assert "ipython install-nbextension" in inner_calls[0]
+    assert "calico-document-tools-1.0.zip" in inner_calls[0]
+
+
+def test_line_install_unknown_package_no_shell_dispatch(tmp_path, monkeypatch) -> None:
+    """An unrecognised package name dispatches no shell command."""
+    kernel, custom_js, inner_calls = _setup(tmp_path, monkeypatch)
+
+    kernel.do_execute("%install my-custom-package")
+
+    assert inner_calls == [], "unexpected shell command dispatched for unknown package"
+    # enable_extension still runs and registers the extension
+    assert 'IPython.load_extensions("my-custom-package");' in custom_js.read_text()
+
+
+# ---------------------------------------------------------------------------
+# enable_extension branches (exercised via line_install with unknown packages)
+# ---------------------------------------------------------------------------
+
+
+def test_enable_extension_already_installed(tmp_path, monkeypatch) -> None:
+    """enable_extension returns early when the extension is already present."""
+    initial = 'IPython.load_extensions("my-ext");\n'
+    kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content=initial)
+
+    kernel.do_execute("%install my-ext")
+
+    assert custom_js.read_text() == initial
+
+
+def test_enable_extension_no_install_magic_marker(tmp_path, monkeypatch) -> None:
+    """enable_extension appends the boilerplate block when // INSTALL MAGIC is absent."""
+    kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content="")
+
+    kernel.do_execute("%install fresh-ext")
+
+    content = custom_js.read_text()
+    assert "// INSTALL MAGIC" in content
+    assert 'IPython.load_extensions("fresh-ext");' in content
+    # extension load call must appear before the marker
+    assert content.index('IPython.load_extensions("fresh-ext");') < content.index(
+        "// INSTALL MAGIC"
+    )
+
+
+def test_enable_extension_existing_install_magic_marker(tmp_path, monkeypatch) -> None:
+    """enable_extension inserts the load call before // INSTALL MAGIC when marker exists."""
+    existing = (
+        'require(["base/js/events"], function (events) {\n'
+        '    events.on("app_initialized.NotebookApp", function () {\n'
+        "        // INSTALL MAGIC\n"
+        "    });\n"
+        "});\n"
+    )
+    kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content=existing)
+
+    kernel.do_execute("%install another-ext")
+
+    content = custom_js.read_text()
+    assert 'IPython.load_extensions("another-ext");' in content
+    assert "// INSTALL MAGIC" in content
+    assert content.index('IPython.load_extensions("another-ext");') < content.index(
+        "// INSTALL MAGIC"
+    )
+    # the marker itself must still be present after the insertion
+    assert content.count("// INSTALL MAGIC") == 1

--- a/tests/magics/test_install_magic.py
+++ b/tests/magics/test_install_magic.py
@@ -51,7 +51,7 @@ def _setup(tmp_path, monkeypatch, initial_content=""):
             }
         return original_do_execute(code, *args, **kwargs)
 
-    kernel.do_execute = capturing_do_execute
+    kernel.do_execute = capturing_do_execute  # type:ignore[method-assign]
     return kernel, custom_js, inner_calls
 
 

--- a/tests/magics/test_kernel_magic.py
+++ b/tests/magics/test_kernel_magic.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,15 +12,15 @@ from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
 @pytest.fixture()
 def ipython_magics(monkeypatch):
     """Yield (kernel_fn, kx_fn, mock_magic) with IPython registration stubbed out."""
-    captured: dict = {}
+    captured: dict[str, Any] = {}
 
     monkeypatch.setattr(
         "IPython.core.magic.register_line_magic",
-        lambda f: captured.update(kernel=f) or f,
+        lambda f: captured.update(kernel=f) or f,  # type:ignore[redundant-expr]
     )
     monkeypatch.setattr(
         "IPython.core.magic.register_cell_magic",
-        lambda f: captured.update(kx=f) or f,
+        lambda f: captured.update(kx=f) or f,  # type:ignore[redundant-expr]
     )
 
     mock_magic = MagicMock()
@@ -47,7 +48,7 @@ def test_line_kernel_default_name() -> None:
     assert "default" in mk.kernels
     assert isinstance(mk.kernels["default"], MetaKernelEcho)
     # parent kernel is wired into the sub-kernel
-    assert mk.kernels["default"].kernel is kernel
+    assert mk.kernels["default"].kernel is kernel  # type:ignore[attr-defined]
 
 
 def test_line_kernel_named() -> None:
@@ -61,7 +62,7 @@ def test_line_kernel_named() -> None:
     assert mk.kernel_name == "linetest_named"
     assert "linetest_named" in mk.kernels
     assert isinstance(mk.kernels["linetest_named"], MetaKernelEcho)
-    assert mk.kernels["linetest_named"].kernel is kernel
+    assert mk.kernels["linetest_named"].kernel is kernel  # type:ignore[attr-defined]
 
 
 def test_line_kernel_invalid_module() -> None:

--- a/tests/magics/test_kernel_magic.py
+++ b/tests/magics/test_kernel_magic.py
@@ -1,4 +1,33 @@
-from tests.utils import EvalKernel, get_kernel, get_log_text
+from unittest.mock import MagicMock
+
+import pytest
+
+import metakernel.magics.kernel_magic as _km
+from metakernel.magics.kernel_magic import register_ipython_magics
+from metakernel_echo.metakernel_echo import MetaKernelEcho
+from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
+
+
+@pytest.fixture()
+def ipython_magics(monkeypatch):
+    """Yield (kernel_fn, kx_fn, mock_magic) with IPython registration stubbed out."""
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        "IPython.core.magic.register_line_magic",
+        lambda f: captured.update(kernel=f) or f,
+    )
+    monkeypatch.setattr(
+        "IPython.core.magic.register_cell_magic",
+        lambda f: captured.update(kx=f) or f,
+    )
+
+    mock_magic = MagicMock()
+    monkeypatch.setattr(_km, "KernelMagic", lambda _kernel: mock_magic)
+
+    register_ipython_magics()
+
+    yield captured["kernel"], captured["kx"], mock_magic
 
 
 def test_kernel_magic() -> None:
@@ -6,3 +35,123 @@ def test_kernel_magic() -> None:
     kernel.do_execute("%kx 42", False)
     results = get_log_text(kernel)
     assert "42" in results, results
+
+
+def test_line_kernel_default_name() -> None:
+    """line_kernel stores the sub-kernel under 'default' when no -k flag is given."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%kernel metakernel_echo.metakernel_echo MetaKernelEcho")
+
+    mk = kernel.line_magics["kernel"]
+    assert mk.kernel_name == "default"
+    assert "default" in mk.kernels
+    assert isinstance(mk.kernels["default"], MetaKernelEcho)
+    # parent kernel is wired into the sub-kernel
+    assert mk.kernels["default"].kernel is kernel
+
+
+def test_line_kernel_named() -> None:
+    """line_kernel stores the sub-kernel under the name given by -k."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(
+        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k linetest_named"
+    )
+
+    mk = kernel.line_magics["kernel"]
+    assert mk.kernel_name == "linetest_named"
+    assert "linetest_named" in mk.kernels
+    assert isinstance(mk.kernels["linetest_named"], MetaKernelEcho)
+    assert mk.kernels["linetest_named"].kernel is kernel
+
+
+def test_line_kernel_invalid_module() -> None:
+    """line_kernel logs an error when the module cannot be imported."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%kernel nonexistent_module_xyz SomeClass")
+
+    assert "Error" in get_log_text(kernel)
+
+
+def test_line_kernel_invalid_class() -> None:
+    """line_kernel logs an error when the class does not exist in the module."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%kernel metakernel_echo.metakernel_echo NoSuchClass")
+
+    assert "Error" in get_log_text(kernel)
+
+
+def test_cell_kx_uses_current_kernel_name() -> None:
+    """%%kx with no -k flag routes execution to the kernel set by the last %kernel call."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(
+        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_default"
+    )
+    clear_log_text(kernel)
+
+    kernel.do_execute("%%kx\nhello world")
+
+    assert "hello world" in get_log_text(kernel)
+
+
+def test_cell_kx_explicit_kernel_name() -> None:
+    """%%kx -k NAME routes execution to the named sub-kernel."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute(
+        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_a"
+    )
+    kernel.do_execute(
+        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_b"
+    )
+    clear_log_text(kernel)
+
+    kernel.do_execute("%%kx -k ctkx_b\nrouted to b")
+
+    assert "routed to b" in get_log_text(kernel)
+
+
+# ---------------------------------------------------------------------------
+# register_ipython_magics - inner `kernel` line-magic function
+# ---------------------------------------------------------------------------
+
+
+def test_ipython_kernel_two_parts_defaults_name(ipython_magics) -> None:
+    """kernel(line) with exactly one space passes kernel_name='default' to line_kernel."""
+    kernel_fn, _, mock_magic = ipython_magics
+
+    kernel_fn("mymodule MyClass")
+
+    mock_magic.line_kernel.assert_called_once_with("mymodule", "MyClass", "default")
+
+
+def test_ipython_kernel_three_parts_uses_provided_name(ipython_magics) -> None:
+    """kernel(line) with two spaces extracts the third token as kernel_name."""
+    kernel_fn, _, mock_magic = ipython_magics
+
+    kernel_fn("mymodule MyClass mykernel")
+
+    mock_magic.line_kernel.assert_called_once_with("mymodule", "MyClass", "mykernel")
+
+
+# ---------------------------------------------------------------------------
+# register_ipython_magics - inner `kx` cell-magic function
+# ---------------------------------------------------------------------------
+
+
+def test_ipython_kx_nonempty_line_uses_line_as_name(ipython_magics) -> None:
+    """kx(line, cell) uses line.strip() as the kernel name when non-empty."""
+    _, kx_fn, mock_magic = ipython_magics
+
+    kx_fn("mykernel", "some code")
+
+    assert mock_magic.code == "some code"
+    mock_magic.cell_kx.assert_called_once_with("mykernel")
+
+
+def test_ipython_kx_empty_line_falls_back_to_default(ipython_magics) -> None:
+    """kx(line, cell) uses 'default' as the kernel name when line is empty."""
+    _, kx_fn, mock_magic = ipython_magics
+
+    kx_fn("", "some code")
+
+    assert mock_magic.code == "some code"
+    mock_magic.cell_kx.assert_called_once_with("default")

--- a/tests/magics/test_macro_magic.py
+++ b/tests/magics/test_macro_magic.py
@@ -1,3 +1,4 @@
+from metakernel.magics.macro_magic import MacroMagic
 from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
 
 
@@ -24,3 +25,166 @@ print("ok")
     text = get_log_text(kernel)
     assert "testme" not in text, text
     clear_log_text(kernel)
+
+
+# ---------------------------------------------------------------------------
+# Branch 1: -l flag  (name variations not yet covered)
+# ---------------------------------------------------------------------------
+
+
+def test_list_system_macros() -> None:
+    """'-l system' prints the system macros and omits the Learned section."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro -l system", False)
+    text = get_log_text(kernel)
+    assert "renumber-cells" in text
+    assert "Learned" not in text
+
+
+def test_list_all_macros() -> None:
+    """'-l all' prints both System and Learned sections."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    mm.learned["list-all-probe"] = "pass\n"
+
+    kernel.do_execute("%macro -l all", False)
+    text = get_log_text(kernel)
+    assert "renumber-cells" in text
+    assert "list-all-probe" in text
+
+
+def test_list_all_shows_both_section_headers() -> None:
+    """'-l all' emits both 'System:' and 'Learned:' section headers."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    mm.learned["section-header-probe"] = "pass\n"
+
+    kernel.do_execute("%macro -l all", False)
+    text = get_log_text(kernel)
+    assert "System:" in text
+    assert "Learned:" in text
+    assert "renumber-cells" in text
+    assert "section-header-probe" in text
+
+
+# ---------------------------------------------------------------------------
+# Branch 2: -s flag
+# ---------------------------------------------------------------------------
+
+
+def test_show_system_macro() -> None:
+    """'-s NAME' for a system macro prints the header and the macro body."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro -s renumber-cells", False)
+    text = get_log_text(kernel)
+    assert "%%macro renumber-cells" in text
+    assert "renumber-cells" in MacroMagic.macros
+    assert MacroMagic.macros["renumber-cells"].split("\n")[0] in text
+
+
+def test_show_learned_macro() -> None:
+    """'-s NAME' for a learned macro prints the header and the macro body."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    mm.learned["show-probe"] = "x = 1\n"
+
+    kernel.do_execute("%macro -s show-probe", False)
+    text = get_log_text(kernel)
+    assert "%%macro show-probe" in text
+    assert "x = 1" in text
+
+
+def test_show_unknown_macro_prints_only_header() -> None:
+    """'-s NAME' for an unknown macro prints just the header with no body."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro -s no-such-macro-xyz", False)
+    text = get_log_text(kernel)
+    assert "%%macro no-such-macro-xyz" in text
+    # no body was appended - only the header line should be present
+    assert text.strip().endswith("%%macro no-such-macro-xyz")
+
+
+# ---------------------------------------------------------------------------
+# Branch 3b-i: learned macro with pre-existing self.code
+# ---------------------------------------------------------------------------
+
+
+def test_execute_learned_macro_with_prior_code() -> None:
+    """A newline separator is inserted when self.code is non-empty before the macro."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    mm.learned["add-y"] = "y = 2\n"
+
+    # The body after the magic line becomes self.code = "x = 1"
+    kernel.do_execute("%macro add-y\nx = 1", False)
+
+    assert kernel.get_variable("x") == 1
+    assert kernel.get_variable("y") == 2
+
+
+# ---------------------------------------------------------------------------
+# Branch 4b / 4b-i: execute a system macro (+ pre-existing code sub-branch)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_system_macro(monkeypatch) -> None:
+    """Executing a system macro appends its body to self.code for evaluation."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    monkeypatch.setitem(mm.macros, "test-sys-exec", "z = 42\n")
+
+    kernel.do_execute("%macro test-sys-exec", False)
+
+    assert kernel.get_variable("z") == 42
+
+
+def test_execute_system_macro_with_prior_code(monkeypatch) -> None:
+    """A newline separator is inserted when self.code is non-empty for a system macro."""
+    kernel = get_kernel(EvalKernel)
+    mm = kernel.line_magics["macro"]
+    monkeypatch.setitem(mm.macros, "test-sys-prior", "b = 2\n")
+
+    kernel.do_execute("%macro test-sys-prior\na = 1", False)
+
+    assert kernel.get_variable("a") == 1
+    assert kernel.get_variable("b") == 2
+
+
+# ---------------------------------------------------------------------------
+# Branch 4a: delete a system macro
+# ---------------------------------------------------------------------------
+
+
+def test_delete_system_macro_raises_error() -> None:
+    """'-d NAME' on a system macro logs an error (raises Exception internally)."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro -d renumber-cells", False)
+    assert "Error" in get_log_text(kernel)
+
+
+# ---------------------------------------------------------------------------
+# Branch 5: empty name
+# ---------------------------------------------------------------------------
+
+
+def test_empty_name_lists_all_macros() -> None:
+    """%macro with no name falls through to _list_macros() showing everything."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro", False)
+    text = get_log_text(kernel)
+    assert "Available macros" in text
+    assert "renumber-cells" in text
+
+
+# ---------------------------------------------------------------------------
+# Branch 6: unknown name
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_name_logs_error() -> None:
+    """%macro with an unrecognised name logs 'No such macro' as an error."""
+    kernel = get_kernel(EvalKernel)
+    kernel.do_execute("%macro totally-unknown-macro-xyz", False)
+    text = get_log_text(kernel)
+    assert "No such macro" in text
+    assert "totally-unknown-macro-xyz" in text


### PR DESCRIPTION
## Summary

- Add line_include tests (single file, trailing code, multiple files, tilde expansion, file not found) to `test_include_magic.py`
- New `test_install_magic.py` covering all `line_install` and `enable_extension` branches (calico packages, unknown package, already-installed, no-marker, existing-marker)
- Add `line_kernel` (default/named/invalid module/invalid class), `cell_kx` (current/explicit kernel name), and `register_ipython_magics` inner-function tests to `test_kernel_magic.py`
- Add `-l system/all/both-headers`, `-s show`, execute learned/system macros, `-d system error`, empty name, and unknown name branch tests to `test_macro_magic.py`
