### PR TITLE
Add tests for core MetaKernel methods

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,15 @@ from typing import Any, TypeVar, overload
 
 from metakernel import MetaKernel
 
+__all__ = [
+    "EvalKernel",
+    "clear_log_text",
+    "get_kernel",
+    "get_log",
+    "get_log_text",
+    "ss",
+]
+
 _KT = TypeVar("_KT", bound=MetaKernel)
 
 try:


### PR DESCRIPTION
## Summary

- Adds `TestMetaKernelRunAsMain` to `test_metakernel_app.py`: verifies `app_name`, `kernel_class`, and extra kwargs are forwarded correctly to `MetaKernelApp.launch_instance`
- Adds `TestMakeSubkernel`: covers both the no-IPython path (copies `session`, `send_response`, `Display` from parent kernel) and the IPython path (pulls `session` from `shell.kernel.session`, sets `Display` to IPython's `display`, binds `send_response` to `_send_shell_response`)
- Adds `TestConstructorWithExtraArgs`: verifies that `do_execute_file` is called for each entry in `parent.extra_args`, exceptions are caught, `redirect_to_log` is restored, and an empty list skips execution
- Adds `TestGetVariable`: base class returns `None`; `EvalKernel` override returns set values and raises `KeyError` for unknown names
- Adds `TestInitializeDebug`: base class always returns `""`
- Adds `TestPostExecuteSilent`: `send_response` is suppressed for all retval types; history (`_ii`/`_iii`) and out (`__`) Python attributes are updated; `kernel_resp["status"]` is set to `"error"` for `ExceptionWrapper`
- Adds `TestDoIsComplete`: all branches — magic prefix vs regular code, trailing newline vs none, empty string, bare newline
- Adds `TestPrintWriteErrorRedirectToLog`: both `redirect_to_log` branches for `Print`, `Write`, and `Error`; confirms `Error` uses `"stderr"` stream name

## Test plan

- [x] `just test tests/test_metakernel.py tests/test_metakernel_app.py` passes