### PR TITLE
Add Python 3.14t free-threading CI on Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
             python-version: "3.12"
           - os: ubuntu-latest
             python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14t"
 
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Adds Python 3.14t (free-threaded build) as an Ubuntu-only include in the test matrix

## Test plan
- [x] CI passes for the new 3.14t job on ubuntu-latest