### PR TITLE
Remove PY3 compatibility shim

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
 
 warnings.filterwarnings("ignore", module="IPython.html.widgets")
 
-PY3 = sys.version_info[0] == 3
-
 try:
     import ipywidgets as widgets  #  type:ignore[import-untyped]
     from ipywidgets.widgets.widget import Widget  #  type:ignore[import-untyped]
@@ -146,8 +144,6 @@ class MetaKernel(Kernel):
         self.max_hist_cache = 1000
         self.hist_cache: list[str] = []
         kwargs = {"parent": self, "kernel": self}
-        if not PY3:
-            kwargs["shell"] = None
         self.comm_manager = comm.get_comm_manager()
         # widgets have changed target name in 8.x, keeping for compatibility
         self.comm_manager.register_target(

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -16,8 +16,6 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 
 _maxsize = sys.maxsize
 
-PY3 = sys.version_info[0] == 3
-
 
 class MagicOptionParser(optparse.OptionParser):
     def error(self, msg: str) -> NoReturn:
@@ -60,7 +58,7 @@ class Magic:
         except Exception as e:
             self.kernel.Error(str(e))
             return self
-        arg_spec = inspect.getfullargspec(func) if PY3 else inspect.getargspec(func)
+        arg_spec = inspect.getfullargspec(func)
         fargs = arg_spec.args
         if fargs[0] == "self":
             fargs = fargs[1:]
@@ -84,7 +82,7 @@ class Magic:
             self.kernel.Error(str(e))
             return self
 
-        arg_spec = inspect.getfullargspec(func) if PY3 else inspect.getargspec(func)
+        arg_spec = inspect.getfullargspec(func)
         fargs = arg_spec.args
         if fargs[0] == "self":
             fargs = fargs[1:]


### PR DESCRIPTION
## Summary

- Remove `PY3 = sys.version_info[0] == 3` from `_metakernel.py` and `magic.py`
- Drop the `if not PY3: kwargs["shell"] = None` branch in `MetaKernel.__init__`
- Simplify both `inspect.getfullargspec(func) if PY3 else inspect.getargspec(func)` calls to just `inspect.getfullargspec(func)`

Since only Python 3 is supported, these shims are dead code.