### PR TITLE
Support async do_execute_direct

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -314,7 +314,7 @@ class MetaKernel(Kernel):
     ############################################
     # Implement base class methods
 
-    def do_execute(
+    async def do_execute(
         self,
         code: Any,
         silent: Any = False,
@@ -399,6 +399,8 @@ class MetaKernel(Kernel):
                     retval = self.do_execute_meta(code[9:].strip())
                 else:
                     retval = self.do_execute_direct(code)
+                    if inspect.isawaitable(retval):
+                        retval = await retval
             # Post-process magics:
             for magic in reversed(stack):
                 retval = magic.post_process(retval)
@@ -407,6 +409,8 @@ class MetaKernel(Kernel):
                 retval = self.do_execute_meta(code[9:].strip())
             else:
                 retval = self.do_execute_direct(code)
+                if inspect.isawaitable(retval):
+                    retval = await retval
 
         self.post_execute(retval, code, silent)
 

--- a/metakernel/magics/install_magic.py
+++ b/metakernel/magics/install_magic.py
@@ -15,21 +15,22 @@ class InstallMagic(Magic):
             %install calico-spell-check
         """
         ## FIXME: get list of known extension names and locations from wiki
-        if package == "calico-publish":
-            self.kernel.do_execute(
-                "!ipython install-nbextension https://bitbucket.org/ipre/calico/raw/master/notebooks/nbextensions/calico-publish.js"
+        shell = self.kernel.line_magics.get("shell")
+        if package == "calico-publish" and shell is not None:
+            shell.line_shell(
+                "ipython install-nbextension https://bitbucket.org/ipre/calico/raw/master/notebooks/nbextensions/calico-publish.js"
             )
-        elif package == "calico-spell-check":
-            self.kernel.do_execute(
-                "!ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-spell-check-1.0.zip"
+        elif package == "calico-spell-check" and shell is not None:
+            shell.line_shell(
+                "ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-spell-check-1.0.zip"
             )
-        elif package == "calico-cell-tools":
-            self.kernel.do_execute(
-                "!ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-cell-tools-1.0.zip"
+        elif package == "calico-cell-tools" and shell is not None:
+            shell.line_shell(
+                "ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-cell-tools-1.0.zip"
             )
-        elif package == "calico-document-tools":
-            self.kernel.do_execute(
-                "!ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-document-tools-1.0.zip"
+        elif package == "calico-document-tools" and shell is not None:
+            shell.line_shell(
+                "ipython install-nbextension https://bitbucket.org/ipre/calico/downloads/calico-document-tools-1.0.zip"
             )
         self.enable_extension(package)
         # FIXME: related %config:

--- a/tests/magics/test_activity_magic.py
+++ b/tests/magics/test_activity_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import os
 import sys
@@ -193,7 +194,9 @@ def test_cell_activity_magic_writes_file(tmp_path) -> None:
     """%%activity writes the cell body to the named file and creates a results file."""
     activity_file = tmp_path / "test_activity"
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(f"%%activity {activity_file}\n{ACTIVITY_TEXT}", False)
+    asyncio.run(
+        kernel.do_execute(f"%%activity {activity_file}\n{ACTIVITY_TEXT}", False)
+    )
 
     assert activity_file.exists()
     assert "poll" in activity_file.read_text()
@@ -205,7 +208,9 @@ def test_cell_activity_magic_displays_widget(tmp_path) -> None:
     """%%activity renders a widget when ipywidgets is available."""
     activity_file = tmp_path / "test_activity"
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(f"%%activity {activity_file}\n{ACTIVITY_TEXT}", False)
+    asyncio.run(
+        kernel.do_execute(f"%%activity {activity_file}\n{ACTIVITY_TEXT}", False)
+    )
 
     assert "Display Widget" in get_log_text(kernel)
 
@@ -222,7 +227,7 @@ def test_line_activity_magic_renders_widget(tmp_path) -> None:
     activity_file.write_text(ACTIVITY_TEXT)
 
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(f"%activity {activity_file}", False)
+    asyncio.run(kernel.do_execute(f"%activity {activity_file}", False))
 
     assert "Display Widget" in get_log_text(kernel)
     assert os.path.exists(str(activity_file) + ".results")

--- a/tests/magics/test_blockly_magic.py
+++ b/tests/magics/test_blockly_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -7,14 +8,14 @@ from tests.utils import EvalKernel, get_kernel, get_log_text, has_network
 
 def test_blockly_default() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%blockly")
+    asyncio.run(kernel.do_execute("%blockly"))
     text = get_log_text(kernel)
     assert "Display Data" in text, text
 
 
 def test_blockly_custom_height() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%blockly --height 600")
+    asyncio.run(kernel.do_execute("%blockly --height 600"))
     text = get_log_text(kernel)
     assert "Display Data" in text, text
 
@@ -23,7 +24,7 @@ def test_blockly_page_from_local(tmp_path) -> None:
     html_file = tmp_path / "blockly_page.html"
     html_file.write_text("<html><body>Blockly</body></html>")
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(f"%blockly --page_from_local {html_file}")
+    asyncio.run(kernel.do_execute(f"%blockly --page_from_local {html_file}"))
     text = get_log_text(kernel)
     assert "Display Data" in text, text
 
@@ -31,8 +32,10 @@ def test_blockly_page_from_local(tmp_path) -> None:
 @pytest.mark.skipif(not has_network(), reason="no network")
 def test_blockly_page_from_origin() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%blockly --page_from_origin https://developers-dot-devsite-v2-prod.appspot.com/blockly/blockly-demo/blockly-demo"
+    asyncio.run(
+        kernel.do_execute(
+            "%blockly --page_from_origin https://developers-dot-devsite-v2-prod.appspot.com/blockly/blockly-demo/blockly-demo"
+        )
     )
     text = get_log_text(kernel)
     assert "Display Data" in text, text
@@ -55,8 +58,10 @@ def test_blockly_template_data_from_local(tmp_path) -> None:
     (tmp_path / "tdata-workspace.xml").write_text("<xml>workspace</xml>")
     (tmp_path / "tdata-blocks.js").write_text("var blocks = {};")
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        f"%blockly --page_from_local {template_html} --template_data {tdata}"
+    asyncio.run(
+        kernel.do_execute(
+            f"%blockly --page_from_local {template_html} --template_data {tdata}"
+        )
     )
     text = get_log_text(kernel)
     assert "Display Data" in text, text

--- a/tests/magics/test_brain_magic.py
+++ b/tests/magics/test_brain_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 
 import pytest
@@ -58,6 +59,6 @@ def test_brain_help() -> None:
 def test_brain_cell_magic_executes() -> None:
     """%%brain executes without error when calysto is available."""
     kernel = get_kernel()
-    kernel.do_execute("%%brain\nrobot.forward(1)", None)
+    asyncio.run(kernel.do_execute("%%brain\nrobot.forward(1)", None))
     magic = kernel.cell_magics["brain"]
     assert magic.code is not None

--- a/tests/magics/test_cd_magic.py
+++ b/tests/magics/test_cd_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 from tests.utils import clear_log_text, get_kernel, get_log_text
@@ -5,8 +6,8 @@ from tests.utils import clear_log_text, get_kernel, get_log_text
 
 def test_cd_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%cd ~")
+    asyncio.run(kernel.do_execute("%cd ~"))
     assert os.getcwd() == os.path.expanduser("~"), os.getcwd()
     clear_log_text(kernel)
-    kernel.do_execute("%cd")
+    asyncio.run(kernel.do_execute("%cd"))
     assert os.getcwd() in get_log_text(kernel)

--- a/tests/magics/test_connect_info_magic.py
+++ b/tests/magics/test_connect_info_magic.py
@@ -1,9 +1,11 @@
+import asyncio
+
 from tests.utils import get_kernel, get_log_text
 
 
 def test_connect_info_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%connect_info")
+    asyncio.run(kernel.do_execute("%connect_info"))
     text = get_log_text(kernel)
     assert (
         """{

--- a/tests/magics/test_conversation_magic.py
+++ b/tests/magics/test_conversation_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import patch
 
 from tests.utils import EvalKernel, get_kernel, get_log_text
@@ -5,7 +6,7 @@ from tests.utils import EvalKernel, get_kernel, get_log_text
 
 def test_conversation_line_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%conversation mysite")
+    asyncio.run(kernel.do_execute("%conversation mysite"))
     text = get_log_text(kernel)
     assert "Display Data" in text, text
 
@@ -28,7 +29,7 @@ def test_conversation_line_magic_sets_evaluate_false() -> None:
 
 def test_conversation_cell_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%%conversation mysite\n")
+    asyncio.run(kernel.do_execute("%%conversation mysite\n"))
     text = get_log_text(kernel)
     assert "Display Data" in text, text
 

--- a/tests/magics/test_debug_magic.py
+++ b/tests/magics/test_debug_magic.py
@@ -1,8 +1,12 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel
 
 
 def test_debug_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%debug
+    asyncio.run(
+        kernel.do_execute("""%%debug
 print('ok')
 """)
+    )

--- a/tests/magics/test_dot_magic.py
+++ b/tests/magics/test_dot_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import shutil
 
@@ -11,10 +12,12 @@ NO_DOT = shutil.which("dot") is None or importlib.util.find_spec("pydot") is Non
 @pytest.mark.skipif(NO_DOT, reason="Requires dot from graphviz")
 def test_dot_magic_cell() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%dot
+    asyncio.run(
+        kernel.do_execute("""%%dot
 
 graph A { a->b };
 """)
+    )
 
     text = get_log_text(kernel)
     assert "Display Data" in text, text
@@ -23,7 +26,7 @@ graph A { a->b };
 @pytest.mark.skipif(NO_DOT, reason="Requires dot from graphviz")
 def test_dot_magic_line() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%dot graph A { a->b };")
+    asyncio.run(kernel.do_execute("%dot graph A { a->b };"))
 
     text = get_log_text(kernel)
     assert "Display Data" in text, text

--- a/tests/magics/test_download_magic.py
+++ b/tests/magics/test_download_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -14,8 +15,10 @@ from tests.utils import (
 @pytest.mark.skipif(not has_network(), reason="no network")
 def test_download_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%download --filename TEST.txt https://raw.githubusercontent.com/calysto/metakernel/main/LICENSE.txt"
+    asyncio.run(
+        kernel.do_execute(
+            "%download --filename TEST.txt https://raw.githubusercontent.com/calysto/metakernel/main/LICENSE.txt"
+        )
     )
     text = get_log_text(kernel)
     assert "Downloaded 'TEST.txt'" in text, text
@@ -23,8 +26,10 @@ def test_download_magic() -> None:
 
     clear_log_text(kernel)
 
-    kernel.do_execute(
-        "%download https://raw.githubusercontent.com/calysto/metakernel/main/LICENSE.txt"
+    asyncio.run(
+        kernel.do_execute(
+            "%download https://raw.githubusercontent.com/calysto/metakernel/main/LICENSE.txt"
+        )
     )
     text = get_log_text(kernel)
     assert "Downloaded 'LICENSE.txt'" in text, text

--- a/tests/magics/test_edit_magic.py
+++ b/tests/magics/test_edit_magic.py
@@ -1,10 +1,12 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel
 
 
 def test_edit_magic() -> None:
     kernel = get_kernel(EvalKernel)
 
-    results = kernel.do_execute("%%edit %s" % __file__)
+    results = asyncio.run(kernel.do_execute("%%edit %s" % __file__))
     text = results["payload"][0]["text"]
     assert text.startswith("%%file")
     assert "def test_edit_magic" in text

--- a/tests/magics/test_file_magic.py
+++ b/tests/magics/test_file_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 from tests.utils import get_kernel
@@ -5,12 +6,14 @@ from tests.utils import get_kernel
 
 def test_file_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute(
-        """%%file TEST.txt
+    asyncio.run(
+        kernel.do_execute(
+            """%%file TEST.txt
 LINE1
 LINE2
 LINE3""",
-        False,
+            False,
+        )
     )
     assert os.path.exists("TEST.txt")
     with open("TEST.txt") as fp:
@@ -20,13 +23,15 @@ LINE3""",
         assert lines[1] == "LINE2\n"
         assert lines[2] == "LINE3"
 
-    kernel.do_execute(
-        """%%file -a TEST.txt
+    asyncio.run(
+        kernel.do_execute(
+            """%%file -a TEST.txt
 
 LINE4
 LINE5
 LINE6""",
-        False,
+            False,
+        )
     )
     assert os.path.exists("TEST.txt")
     with open("TEST.txt") as fp:
@@ -36,10 +41,12 @@ LINE6""",
         assert lines[4] == "LINE5\n"
         assert lines[5] == "LINE6"
 
-    kernel.do_execute("""%%file /tmp/tmp/TEST.txt
+    asyncio.run(
+        kernel.do_execute("""%%file /tmp/tmp/TEST.txt
 TEST1
 TEST2
 TEST3""")
+    )
     with open("/tmp/tmp/TEST.txt") as fp:
         lines = fp.readlines()
         assert len(lines) == 3

--- a/tests/magics/test_help_magic.py
+++ b/tests/magics/test_help_magic.py
@@ -1,34 +1,36 @@
+import asyncio
+
 from tests.utils import clear_log_text, get_kernel, get_log_text
 
 
 def test_help_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("?%magic", None)
+    asyncio.run(kernel.do_execute("?%magic", None))
     text = get_log_text(kernel)
     assert "%magic - show installed magics" in text, repr(text)
 
-    kernel.do_execute("%lsmagic??", None)
+    asyncio.run(kernel.do_execute("%lsmagic??", None))
     text = get_log_text(kernel)
     assert "class LSMagicMagic" in text
 
-    kernel.do_execute("?", None)
+    asyncio.run(kernel.do_execute("?", None))
     text = get_log_text(kernel)
     assert "This is a usage statement." in text
 
-    kernel.do_execute("?%", None)
+    asyncio.run(kernel.do_execute("?%", None))
     text = get_log_text(kernel)
     assert "This is a usage statement." in text
 
-    kernel.do_execute("?%whatwhat", None)
+    asyncio.run(kernel.do_execute("?%whatwhat", None))
     text = get_log_text(kernel)
     assert "No such line magic 'whatwhat'" in text
 
     clear_log_text(kernel)
 
-    kernel.do_execute("%%help %magic", None)
+    asyncio.run(kernel.do_execute("%%help %magic", None))
     text = get_log_text(kernel)
     assert "MagicMagic" in text
 
-    kernel.do_execute("%%help\n%python", None)
+    asyncio.run(kernel.do_execute("%%help\n%python", None))
     text = get_log_text(kernel)
     assert "PythonMagic" in text

--- a/tests/magics/test_html_magic.py
+++ b/tests/magics/test_html_magic.py
@@ -1,11 +1,15 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 
 def test_html_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%html
+    asyncio.run(
+        kernel.do_execute("""%%html
 
 <b>bold</b>
 """)
+    )
     text = get_log_text(kernel)
     assert "Display Data" in text, text

--- a/tests/magics/test_include_magic.py
+++ b/tests/magics/test_include_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 from tests.utils import get_kernel, get_log_text
@@ -17,17 +18,17 @@ def test_include_magic() -> None:
     FILE = __file__
     if FILE.endswith(".pyc"):
         FILE = FILE[:-1]
-    kernel.do_execute("%%include %s" % FILE)
+    asyncio.run(kernel.do_execute("%%include %s" % FILE))
     assert "metakernel" in EXECUTION
     assert ("AND " + "THIS") not in EXECUTION
 
     EXECUTION = ""
-    kernel.do_execute(("%%include %s\nAND" + " THIS") % FILE)
+    asyncio.run(kernel.do_execute(("%%include %s\nAND" + " THIS") % FILE))
     assert "metakernel" in EXECUTION
     assert ("AND " + "THIS") in EXECUTION
 
     EXECUTION = ""
-    kernel.do_execute("%%include '%s' '%s'" % (FILE, FILE))
+    asyncio.run(kernel.do_execute("%%include '%s' '%s'" % (FILE, FILE)))
     assert "metakernel" in EXECUTION
     assert ("AND " + "THIS") not in EXECUTION
 
@@ -45,7 +46,7 @@ def test_line_include_single_file(tmp_path) -> None:
     f = tmp_path / "snippet.py"
     f.write_text("x = 42\n")
 
-    kernel.do_execute(f"%include {f}")
+    asyncio.run(kernel.do_execute(f"%include {f}"))
     assert executed, "do_execute_direct was never called"
     assert "x = 42" in executed[-1]
 
@@ -63,7 +64,7 @@ def test_line_include_with_trailing_code(tmp_path) -> None:
     f = tmp_path / "snippet.py"
     f.write_text("y = 10\n")
 
-    kernel.do_execute(f"%include {f}\nz = 20")
+    asyncio.run(kernel.do_execute(f"%include {f}\nz = 20"))
     assert executed
     result = executed[-1]
     assert "y = 10" in result
@@ -85,7 +86,7 @@ def test_line_include_multiple_files(tmp_path) -> None:
     f2 = tmp_path / "b.py"
     f2.write_text("b = 2\n")
 
-    kernel.do_execute(f"%include {f1} {f2}")
+    asyncio.run(kernel.do_execute(f"%include {f1} {f2}"))
     assert executed
     result = executed[-1]
     assert "a = 1" in result
@@ -112,7 +113,7 @@ def test_line_include_tilde_expansion(tmp_path, monkeypatch) -> None:
         lambda p: str(f) if p == "~/home_snippet.py" else original_expanduser(p),
     )
 
-    kernel.do_execute("%include ~/home_snippet.py")
+    asyncio.run(kernel.do_execute("%include ~/home_snippet.py"))
     assert executed
     assert "home_var = True" in executed[-1]
 
@@ -120,6 +121,6 @@ def test_line_include_tilde_expansion(tmp_path, monkeypatch) -> None:
 def test_line_include_file_not_found() -> None:
     """Test that including a nonexistent file logs an error."""
     kernel = get_kernel()
-    kernel.do_execute("%include /nonexistent_path_xyz_abc/file.py")
+    asyncio.run(kernel.do_execute("%include /nonexistent_path_xyz_abc/file.py"))
     log_text = get_log_text(kernel)
     assert "Error" in log_text

--- a/tests/magics/test_install_magic.py
+++ b/tests/magics/test_install_magic.py
@@ -46,7 +46,7 @@ def _setup(tmp_path, monkeypatch, initial_content=""):
         inner_calls.append("!" + command)
         return None
 
-    shell_magic.line_shell = capturing_line_shell  # type:ignore[method-assign]
+    shell_magic.line_shell = capturing_line_shell
     return kernel, custom_js, inner_calls
 
 

--- a/tests/magics/test_install_magic.py
+++ b/tests/magics/test_install_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 
@@ -22,9 +23,9 @@ _CUSTOM_JS_TILDE = "~/.ipython/profile_default/static/custom/custom.js"
 def _setup(tmp_path, monkeypatch, initial_content=""):
     """Return (kernel, custom_js_path, inner_calls).
 
-    The kernel's do_execute is wrapped so that any !-prefixed (shell) call is
-    captured in *inner_calls* rather than actually executed.  expanduser is
-    patched to redirect the custom.js path to a temp file.
+    The shell magic's line_shell is wrapped so that calls are captured in
+    *inner_calls* rather than actually executed.  expanduser is patched to
+    redirect the custom.js path to a temp file.
     """
     custom_js = tmp_path / "custom.js"
     custom_js.write_text(initial_content)
@@ -38,20 +39,14 @@ def _setup(tmp_path, monkeypatch, initial_content=""):
 
     kernel = get_kernel()
     inner_calls: list[str] = []
-    original_do_execute = kernel.do_execute
+    shell_magic = kernel.line_magics["shell"]
+    original_line_shell = shell_magic.line_shell
 
-    def capturing_do_execute(code, *args, **kwargs):
-        if code.startswith("!"):
-            inner_calls.append(code)
-            return {
-                "status": "ok",
-                "execution_count": 0,
-                "payload": [],
-                "user_expressions": {},
-            }
-        return original_do_execute(code, *args, **kwargs)
+    def capturing_line_shell(command, *args, **kwargs):
+        inner_calls.append("!" + command)
+        return None
 
-    kernel.do_execute = capturing_do_execute  # type:ignore[method-assign]
+    shell_magic.line_shell = capturing_line_shell  # type:ignore[method-assign]
     return kernel, custom_js, inner_calls
 
 
@@ -64,7 +59,7 @@ def test_line_install_calico_publish(tmp_path, monkeypatch) -> None:
     """calico-publish dispatches the correct ipython install-nbextension URL."""
     kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
 
-    kernel.do_execute("%install calico-publish")
+    asyncio.run(kernel.do_execute("%install calico-publish"))
 
     assert len(inner_calls) == 1
     assert "ipython install-nbextension" in inner_calls[0]
@@ -75,7 +70,7 @@ def test_line_install_calico_spell_check(tmp_path, monkeypatch) -> None:
     """calico-spell-check dispatches the correct ipython install-nbextension URL."""
     kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
 
-    kernel.do_execute("%install calico-spell-check")
+    asyncio.run(kernel.do_execute("%install calico-spell-check"))
 
     assert len(inner_calls) == 1
     assert "ipython install-nbextension" in inner_calls[0]
@@ -86,7 +81,7 @@ def test_line_install_calico_cell_tools(tmp_path, monkeypatch) -> None:
     """calico-cell-tools dispatches the correct ipython install-nbextension URL."""
     kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
 
-    kernel.do_execute("%install calico-cell-tools")
+    asyncio.run(kernel.do_execute("%install calico-cell-tools"))
 
     assert len(inner_calls) == 1
     assert "ipython install-nbextension" in inner_calls[0]
@@ -97,7 +92,7 @@ def test_line_install_calico_document_tools(tmp_path, monkeypatch) -> None:
     """calico-document-tools dispatches the correct ipython install-nbextension URL."""
     kernel, _, inner_calls = _setup(tmp_path, monkeypatch)
 
-    kernel.do_execute("%install calico-document-tools")
+    asyncio.run(kernel.do_execute("%install calico-document-tools"))
 
     assert len(inner_calls) == 1
     assert "ipython install-nbextension" in inner_calls[0]
@@ -108,7 +103,7 @@ def test_line_install_unknown_package_no_shell_dispatch(tmp_path, monkeypatch) -
     """An unrecognised package name dispatches no shell command."""
     kernel, custom_js, inner_calls = _setup(tmp_path, monkeypatch)
 
-    kernel.do_execute("%install my-custom-package")
+    asyncio.run(kernel.do_execute("%install my-custom-package"))
 
     assert inner_calls == [], "unexpected shell command dispatched for unknown package"
     # enable_extension still runs and registers the extension
@@ -125,7 +120,7 @@ def test_enable_extension_already_installed(tmp_path, monkeypatch) -> None:
     initial = 'IPython.load_extensions("my-ext");\n'
     kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content=initial)
 
-    kernel.do_execute("%install my-ext")
+    asyncio.run(kernel.do_execute("%install my-ext"))
 
     assert custom_js.read_text() == initial
 
@@ -134,7 +129,7 @@ def test_enable_extension_no_install_magic_marker(tmp_path, monkeypatch) -> None
     """enable_extension appends the boilerplate block when // INSTALL MAGIC is absent."""
     kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content="")
 
-    kernel.do_execute("%install fresh-ext")
+    asyncio.run(kernel.do_execute("%install fresh-ext"))
 
     content = custom_js.read_text()
     assert "// INSTALL MAGIC" in content
@@ -156,7 +151,7 @@ def test_enable_extension_existing_install_magic_marker(tmp_path, monkeypatch) -
     )
     kernel, custom_js, _ = _setup(tmp_path, monkeypatch, initial_content=existing)
 
-    kernel.do_execute("%install another-ext")
+    asyncio.run(kernel.do_execute("%install another-ext"))
 
     content = custom_js.read_text()
     assert 'IPython.load_extensions("another-ext");' in content

--- a/tests/magics/test_install_magic_magic.py
+++ b/tests/magics/test_install_magic_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 import sys
@@ -22,8 +23,10 @@ filename = get_local_magics_dir() + os.sep + "cd_magic.py"
 @pytest.mark.skipif(not has_network(), reason="no network")
 def test_install_magic_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%install_magic https://raw.githubusercontent.com/calysto/metakernel/main/metakernel/magics/cd_magic.py"
+    asyncio.run(
+        kernel.do_execute(
+            "%install_magic https://raw.githubusercontent.com/calysto/metakernel/main/metakernel/magics/cd_magic.py"
+        )
     )
     text = get_log_text(kernel)
     assert re.match(

--- a/tests/magics/test_javascript_magic.py
+++ b/tests/magics/test_javascript_magic.py
@@ -1,11 +1,15 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 
 def test_javascript_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%javascript
+    asyncio.run(
+        kernel.do_execute("""%%javascript
 
 console.log("Hello from Javascript");
 """)
+    )
     text = get_log_text(kernel)
     assert "Display Data" in text, text

--- a/tests/magics/test_jigsaw_magic.py
+++ b/tests/magics/test_jigsaw_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -13,7 +14,7 @@ from tests.utils import (
 @pytest.mark.skipif(not has_network(), reason="no network")
 def test_jigsaw_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%jigsaw Processing --workspace workspace1")
+    asyncio.run(kernel.do_execute("%jigsaw Processing --workspace workspace1"))
     text = get_log_text(kernel)
     assert os.path.isfile("workspace1.html"), "File does not exist: workspace1.html"
 

--- a/tests/magics/test_kernel_magic.py
+++ b/tests/magics/test_kernel_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -33,7 +34,7 @@ def ipython_magics(monkeypatch):
 
 def test_kernel_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%kx 42", False)
+    asyncio.run(kernel.do_execute("%kx 42", False))
     results = get_log_text(kernel)
     assert "42" in results, results
 
@@ -41,7 +42,9 @@ def test_kernel_magic() -> None:
 def test_line_kernel_default_name() -> None:
     """line_kernel stores the sub-kernel under 'default' when no -k flag is given."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%kernel metakernel_echo.metakernel_echo MetaKernelEcho")
+    asyncio.run(
+        kernel.do_execute("%kernel metakernel_echo.metakernel_echo MetaKernelEcho")
+    )
 
     mk = kernel.line_magics["kernel"]
     assert mk.kernel_name == "default"
@@ -54,8 +57,10 @@ def test_line_kernel_default_name() -> None:
 def test_line_kernel_named() -> None:
     """line_kernel stores the sub-kernel under the name given by -k."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k linetest_named"
+    asyncio.run(
+        kernel.do_execute(
+            "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k linetest_named"
+        )
     )
 
     mk = kernel.line_magics["kernel"]
@@ -68,7 +73,7 @@ def test_line_kernel_named() -> None:
 def test_line_kernel_invalid_module() -> None:
     """line_kernel logs an error when the module cannot be imported."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%kernel nonexistent_module_xyz SomeClass")
+    asyncio.run(kernel.do_execute("%kernel nonexistent_module_xyz SomeClass"))
 
     assert "Error" in get_log_text(kernel)
 
@@ -76,7 +81,9 @@ def test_line_kernel_invalid_module() -> None:
 def test_line_kernel_invalid_class() -> None:
     """line_kernel logs an error when the class does not exist in the module."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%kernel metakernel_echo.metakernel_echo NoSuchClass")
+    asyncio.run(
+        kernel.do_execute("%kernel metakernel_echo.metakernel_echo NoSuchClass")
+    )
 
     assert "Error" in get_log_text(kernel)
 
@@ -84,12 +91,14 @@ def test_line_kernel_invalid_class() -> None:
 def test_cell_kx_uses_current_kernel_name() -> None:
     """%%kx with no -k flag routes execution to the kernel set by the last %kernel call."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_default"
+    asyncio.run(
+        kernel.do_execute(
+            "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_default"
+        )
     )
     clear_log_text(kernel)
 
-    kernel.do_execute("%%kx\nhello world")
+    asyncio.run(kernel.do_execute("%%kx\nhello world"))
 
     assert "hello world" in get_log_text(kernel)
 
@@ -97,15 +106,19 @@ def test_cell_kx_uses_current_kernel_name() -> None:
 def test_cell_kx_explicit_kernel_name() -> None:
     """%%kx -k NAME routes execution to the named sub-kernel."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_a"
+    asyncio.run(
+        kernel.do_execute(
+            "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_a"
+        )
     )
-    kernel.do_execute(
-        "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_b"
+    asyncio.run(
+        kernel.do_execute(
+            "%kernel metakernel_echo.metakernel_echo MetaKernelEcho -k ctkx_b"
+        )
     )
     clear_log_text(kernel)
 
-    kernel.do_execute("%%kx -k ctkx_b\nrouted to b")
+    asyncio.run(kernel.do_execute("%%kx -k ctkx_b\nrouted to b"))
 
     assert "routed to b" in get_log_text(kernel)
 

--- a/tests/magics/test_latex_magic.py
+++ b/tests/magics/test_latex_magic.py
@@ -1,17 +1,21 @@
+import asyncio
+
 from tests.utils import clear_log_text, get_kernel, get_log_text
 
 
 def test_latex_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%latex $x_1 = \\dfrac{a}{b}$")
+    asyncio.run(kernel.do_execute("%latex $x_1 = \\dfrac{a}{b}$"))
     text = get_log_text(kernel)
     assert "Display Data" in text
 
     clear_log_text(kernel)
 
-    kernel.do_execute("""%%latex
+    asyncio.run(
+        kernel.do_execute("""%%latex
             $x_1 = \\dfrac{a}{b}$
 
             $x_2 = a^{n - 1}$""")
+    )
     text = get_log_text(kernel)
     assert "Display Data" in text

--- a/tests/magics/test_load_magic.py
+++ b/tests/magics/test_load_magic.py
@@ -1,7 +1,9 @@
+import asyncio
+
 from tests.utils import get_kernel
 
 
 def test_load_magic() -> None:
     kernel = get_kernel()
-    ret = kernel.do_execute("%%load %s" % __file__)
+    ret = asyncio.run(kernel.do_execute("%%load %s" % __file__))
     assert "def test_load_magic" in ret["payload"][0]["text"]

--- a/tests/magics/test_ls_magic.py
+++ b/tests/magics/test_ls_magic.py
@@ -1,15 +1,17 @@
+import asyncio
+
 from tests.utils import clear_log_text, get_kernel, get_log_text
 
 
 def test_ls_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%ls /tmp")
+    asyncio.run(kernel.do_execute("%ls /tmp"))
     text = get_log_text(kernel)
     ## FIXME: failing on Travis
     # assert '/tmp/' in text, text[:100]
     clear_log_text(kernel)
 
-    kernel.do_execute("%ls /tmp --recursive")
+    asyncio.run(kernel.do_execute("%ls /tmp --recursive"))
     text = get_log_text(kernel)
     ## FIXME: failing on Travis
     # assert '/tmp' in text, text[:100]

--- a/tests/magics/test_lsmagic_magic.py
+++ b/tests/magics/test_lsmagic_magic.py
@@ -1,9 +1,11 @@
+import asyncio
+
 from tests.utils import get_kernel, get_log_text
 
 
 def test_lsmagic_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%lsmagic")
+    asyncio.run(kernel.do_execute("%lsmagic"))
     text = get_log_text(kernel)
 
     for item in "%cd %connect_info %download %edit %help %html %install_magic %javascript %kernel %kx %latex %load %lsmagic %magic %parallel %plot %pmap %px %python %reload_magics %restart %run %shell %macro %%debug %%file %%help %%html %%javascript %%kx %%latex %%processing %%px %%python %%shell %%show %%macro %%time".split():

--- a/tests/magics/test_macro_magic.py
+++ b/tests/magics/test_macro_magic.py
@@ -1,27 +1,31 @@
+import asyncio
+
 from metakernel.magics.macro_magic import MacroMagic
 from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
 
 
 def test_macro_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute(
-        """%%macro testme
+    asyncio.run(
+        kernel.do_execute(
+            """%%macro testme
 print("ok")
     """,
-        False,
+            False,
+        )
     )
-    kernel.do_execute("%macro testme", False)
+    asyncio.run(kernel.do_execute("%macro testme", False))
     text = get_log_text(kernel)
     assert "ok" in text, text
     clear_log_text(kernel)
 
-    kernel.do_execute("%macro -l learned", False)
+    asyncio.run(kernel.do_execute("%macro -l learned", False))
     text = get_log_text(kernel)
     assert "testme" in text, text
     clear_log_text(kernel)
 
-    kernel.do_execute("%macro -d testme", False)
-    kernel.do_execute("%macro -l learned", False)
+    asyncio.run(kernel.do_execute("%macro -d testme", False))
+    asyncio.run(kernel.do_execute("%macro -l learned", False))
     text = get_log_text(kernel)
     assert "testme" not in text, text
     clear_log_text(kernel)
@@ -35,7 +39,7 @@ print("ok")
 def test_list_system_macros() -> None:
     """'-l system' prints the system macros and omits the Learned section."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro -l system", False)
+    asyncio.run(kernel.do_execute("%macro -l system", False))
     text = get_log_text(kernel)
     assert "renumber-cells" in text
     assert "Learned" not in text
@@ -47,7 +51,7 @@ def test_list_all_macros() -> None:
     mm = kernel.line_magics["macro"]
     mm.learned["list-all-probe"] = "pass\n"
 
-    kernel.do_execute("%macro -l all", False)
+    asyncio.run(kernel.do_execute("%macro -l all", False))
     text = get_log_text(kernel)
     assert "renumber-cells" in text
     assert "list-all-probe" in text
@@ -59,7 +63,7 @@ def test_list_all_shows_both_section_headers() -> None:
     mm = kernel.line_magics["macro"]
     mm.learned["section-header-probe"] = "pass\n"
 
-    kernel.do_execute("%macro -l all", False)
+    asyncio.run(kernel.do_execute("%macro -l all", False))
     text = get_log_text(kernel)
     assert "System:" in text
     assert "Learned:" in text
@@ -75,7 +79,7 @@ def test_list_all_shows_both_section_headers() -> None:
 def test_show_system_macro() -> None:
     """'-s NAME' for a system macro prints the header and the macro body."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro -s renumber-cells", False)
+    asyncio.run(kernel.do_execute("%macro -s renumber-cells", False))
     text = get_log_text(kernel)
     assert "%%macro renumber-cells" in text
     assert "renumber-cells" in MacroMagic.macros
@@ -88,7 +92,7 @@ def test_show_learned_macro() -> None:
     mm = kernel.line_magics["macro"]
     mm.learned["show-probe"] = "x = 1\n"
 
-    kernel.do_execute("%macro -s show-probe", False)
+    asyncio.run(kernel.do_execute("%macro -s show-probe", False))
     text = get_log_text(kernel)
     assert "%%macro show-probe" in text
     assert "x = 1" in text
@@ -97,7 +101,7 @@ def test_show_learned_macro() -> None:
 def test_show_unknown_macro_prints_only_header() -> None:
     """'-s NAME' for an unknown macro prints just the header with no body."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro -s no-such-macro-xyz", False)
+    asyncio.run(kernel.do_execute("%macro -s no-such-macro-xyz", False))
     text = get_log_text(kernel)
     assert "%%macro no-such-macro-xyz" in text
     # no body was appended - only the header line should be present
@@ -116,7 +120,7 @@ def test_execute_learned_macro_with_prior_code() -> None:
     mm.learned["add-y"] = "y = 2\n"
 
     # The body after the magic line becomes self.code = "x = 1"
-    kernel.do_execute("%macro add-y\nx = 1", False)
+    asyncio.run(kernel.do_execute("%macro add-y\nx = 1", False))
 
     assert kernel.get_variable("x") == 1
     assert kernel.get_variable("y") == 2
@@ -133,7 +137,7 @@ def test_execute_system_macro(monkeypatch) -> None:
     mm = kernel.line_magics["macro"]
     monkeypatch.setitem(mm.macros, "test-sys-exec", "z = 42\n")
 
-    kernel.do_execute("%macro test-sys-exec", False)
+    asyncio.run(kernel.do_execute("%macro test-sys-exec", False))
 
     assert kernel.get_variable("z") == 42
 
@@ -144,7 +148,7 @@ def test_execute_system_macro_with_prior_code(monkeypatch) -> None:
     mm = kernel.line_magics["macro"]
     monkeypatch.setitem(mm.macros, "test-sys-prior", "b = 2\n")
 
-    kernel.do_execute("%macro test-sys-prior\na = 1", False)
+    asyncio.run(kernel.do_execute("%macro test-sys-prior\na = 1", False))
 
     assert kernel.get_variable("a") == 1
     assert kernel.get_variable("b") == 2
@@ -158,7 +162,7 @@ def test_execute_system_macro_with_prior_code(monkeypatch) -> None:
 def test_delete_system_macro_raises_error() -> None:
     """'-d NAME' on a system macro logs an error (raises Exception internally)."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro -d renumber-cells", False)
+    asyncio.run(kernel.do_execute("%macro -d renumber-cells", False))
     assert "Error" in get_log_text(kernel)
 
 
@@ -170,7 +174,7 @@ def test_delete_system_macro_raises_error() -> None:
 def test_empty_name_lists_all_macros() -> None:
     """%macro with no name falls through to _list_macros() showing everything."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro", False)
+    asyncio.run(kernel.do_execute("%macro", False))
     text = get_log_text(kernel)
     assert "Available macros" in text
     assert "renumber-cells" in text
@@ -184,7 +188,7 @@ def test_empty_name_lists_all_macros() -> None:
 def test_unknown_name_logs_error() -> None:
     """%macro with an unrecognised name logs 'No such macro' as an error."""
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%macro totally-unknown-macro-xyz", False)
+    asyncio.run(kernel.do_execute("%macro totally-unknown-macro-xyz", False))
     text = get_log_text(kernel)
     assert "No such macro" in text
     assert "totally-unknown-macro-xyz" in text

--- a/tests/magics/test_magic_magic.py
+++ b/tests/magics/test_magic_magic.py
@@ -1,8 +1,10 @@
+import asyncio
+
 from tests.utils import get_kernel, get_log_text
 
 
 def test_magic_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%magic", None)
+    asyncio.run(kernel.do_execute("%magic", None))
     text = get_log_text(kernel)
     assert "! COMMAND ... - execute command in shell" in text

--- a/tests/magics/test_matplotlib_magic.py
+++ b/tests/magics/test_matplotlib_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 
 import pytest
@@ -24,7 +25,7 @@ def test_matplotlib_magic_sets_backend() -> None:
     import matplotlib
 
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%matplotlib agg", False)
+    asyncio.run(kernel.do_execute("%matplotlib agg", False))
 
     assert matplotlib.get_backend().lower() == "agg"
 
@@ -34,7 +35,7 @@ def test_matplotlib_magic_notebook_alias() -> None:
     import matplotlib
 
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%matplotlib notebook", False)
+    asyncio.run(kernel.do_execute("%matplotlib notebook", False))
 
     assert matplotlib.get_backend().lower() == "nbagg"
 
@@ -46,6 +47,6 @@ def test_matplotlib_magic_patches_ipython_display() -> None:
     import metakernel.display
 
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%matplotlib agg", False)
+    asyncio.run(kernel.do_execute("%matplotlib agg", False))
 
     assert IPython.display.display is metakernel.display.display

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import pytest
@@ -17,9 +18,11 @@ NO_IPYPARALLEL = ipyparallel is None
 def test_parallel_magic() -> None:
     kernel = get_kernel(EvalKernel)
     # start up an EvalKernel on each node:
-    kernel.do_execute("%parallel metakernel_python MetaKernelPython", False)
+    asyncio.run(
+        kernel.do_execute("%parallel metakernel_python MetaKernelPython", False)
+    )
     # Now, execute something on each one:
-    kernel.do_execute("%px cluster_rank", False)
+    asyncio.run(kernel.do_execute("%px cluster_rank", False))
     results = get_log_text(kernel)
     assert "[0, 1, 2]" in results, results
 

--- a/tests/magics/test_pipe_magic.py
+++ b/tests/magics/test_pipe_magic.py
@@ -1,9 +1,12 @@
+import asyncio
+
 from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
 
 
 def test_pipe_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""
+    asyncio.run(
+        kernel.do_execute("""
 
 def upper(text):
     return text.upper()
@@ -21,27 +24,36 @@ def piglatin(text):
     return " ".join([pl_word(word) for word in text.split(" ")])
 
 """)
-    kernel.do_execute("""%%pipe upper
+    )
+    asyncio.run(
+        kernel.do_execute("""%%pipe upper
 this is a test
  """)
+    )
     text = get_log_text(kernel)
     assert "THIS IS A TEST" in text, "text: " + text
 
-    kernel.do_execute("""%%pipe upper | piglatin
+    asyncio.run(
+        kernel.do_execute("""%%pipe upper | piglatin
 this is a test
  """)
+    )
     text = get_log_text(kernel)
     assert "HISTay IS A ESTTay" in text, "text: " + text
 
-    kernel.do_execute("""%%pipe piglatin | upper
+    asyncio.run(
+        kernel.do_execute("""%%pipe piglatin | upper
 this is a test
  """)
+    )
     text = get_log_text(kernel)
     assert "HISTAY IS A ESTTAY" in text, "text: " + text
 
-    kernel.do_execute("""%%pipe piglatin | upper | lower
+    asyncio.run(
+        kernel.do_execute("""%%pipe piglatin | upper | lower
 this is a test
  """)
+    )
     text = get_log_text(kernel)
     assert "histay is a esttay" in text, "text: " + text
     clear_log_text(kernel)

--- a/tests/magics/test_plot_magic.py
+++ b/tests/magics/test_plot_magic.py
@@ -1,9 +1,11 @@
+import asyncio
+
 from tests.utils import get_kernel
 
 
 def test_plot_magic_backend() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%plot qt -f svg -s400,200", None)
+    asyncio.run(kernel.do_execute("%plot qt -f svg -s400,200", None))
     assert kernel.plot_settings["width"] == 400
     assert kernel.plot_settings["height"] == 200
     assert kernel.plot_settings["format"] == "svg"
@@ -12,7 +14,7 @@ def test_plot_magic_backend() -> None:
 
 def test_plot_magic_format() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%plot qt -f svg -w 500 -h 400 -r 200")
+    asyncio.run(kernel.do_execute("%plot qt -f svg -w 500 -h 400 -r 200"))
     assert kernel.plot_settings["backend"] == "qt", kernel.plot_settings
     assert kernel.plot_settings["format"] == "svg", kernel.plot_settings
     assert kernel.plot_settings["width"] == 500, kernel.plot_settings
@@ -22,7 +24,7 @@ def test_plot_magic_format() -> None:
 
 def test_plot_magic_size() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%plot qt4 -s 400,200")
+    asyncio.run(kernel.do_execute("%plot qt4 -s 400,200"))
     assert kernel.plot_settings["width"] == 400
     assert kernel.plot_settings["height"] == 200
     assert kernel.plot_settings["backend"] == "qt4", kernel.plot_settings
@@ -30,7 +32,7 @@ def test_plot_magic_size() -> None:
 
 def test_plot_magic_all() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%plot -b qt5 -f svg -s 400,200")
+    asyncio.run(kernel.do_execute("%plot -b qt5 -f svg -s 400,200"))
     assert kernel.plot_settings["width"] == 400
     assert kernel.plot_settings["height"] == 200
     assert kernel.plot_settings["format"] == "svg", kernel.plot_settings

--- a/tests/magics/test_processing_magic.py
+++ b/tests/magics/test_processing_magic.py
@@ -1,9 +1,12 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 
 def test_processing_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%processing
+    asyncio.run(
+        kernel.do_execute("""%%processing
 
 setup() {
 }
@@ -11,5 +14,6 @@ setup() {
 draw() {
 }
 """)
+    )
     text = get_log_text(kernel)
     assert "Display Data" in text, text

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import textwrap
 
 from tests.utils import clear_log_text, get_kernel, get_log_text
@@ -17,70 +18,74 @@ def test_python_magic() -> None:
 
 def test_python_magic2() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%python retval = 1", None)
+    asyncio.run(kernel.do_execute("%python retval = 1", None))
     assert "1" in get_log_text(kernel)
 
-    kernel.do_execute(
-        textwrap.dedent("""\
+    asyncio.run(
+        kernel.do_execute(
+            textwrap.dedent("""\
     %%python
     def test(a):
         return a + 1
     retval = test(2)"""),
-        None,
+            None,
+        )
     )
     assert "3" in get_log_text(kernel)
 
-    kernel.do_execute(
-        textwrap.dedent("""\
+    asyncio.run(
+        kernel.do_execute(
+            textwrap.dedent("""\
     %%python
     def test(a):
         return a + 1
     test(2)"""),
-        None,
+            None,
+        )
     )
     assert "3" in get_log_text(kernel)
 
 
 def test_python_magic3() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%%python -e\n1 + 2", None)
+    asyncio.run(kernel.do_execute("%%python -e\n1 + 2", None))
     magic = kernel.get_magic("%%python")
     assert magic.retval is None  # type:ignore[attr-defined]
 
     kernel = get_kernel()
-    kernel.do_execute("%%python\n1 + 2", None)
+    asyncio.run(kernel.do_execute("%%python\n1 + 2", None))
     magic = kernel.get_magic("%%python")
     assert magic.retval == 3  # type:ignore[attr-defined]
 
     kernel = get_kernel()
-    kernel.do_execute("%%python\n1 + 2\n2 + 3", None)
+    asyncio.run(kernel.do_execute("%%python\n1 + 2\n2 + 3", None))
     magic = kernel.get_magic("%%python")
     assert magic.retval == 5  # type:ignore[attr-defined]
 
     kernel = get_kernel()
-    kernel.do_execute("%%python\nretval = 1 + 2\n2 + 3", None)
+    asyncio.run(kernel.do_execute("%%python\nretval = 1 + 2\n2 + 3", None))
     magic = kernel.get_magic("%%python")
     assert magic.retval == 3  # type:ignore[attr-defined]
 
     kernel = get_kernel()
-    kernel.do_execute("%%python\nimport math", None)
+    asyncio.run(kernel.do_execute("%%python\nimport math", None))
     magic = kernel.get_magic("%%python")
     assert magic.retval is None  # type:ignore[attr-defined]
 
 
 def test_python_magic4() -> None:
     kernel = get_kernel()
-    kernel.do_execute("?%python", None)
+    asyncio.run(kernel.do_execute("?%python", None))
     assert "%python CODE" in get_log_text(kernel)
 
     clear_log_text(kernel)
 
-    ret = kernel.do_execute("?%python a", None)
+    ret = asyncio.run(kernel.do_execute("?%python a", None))
     assert ret["payload"][0]["data"]["text/plain"] == 'No help available for "a"'
-    ret = kernel.do_execute("?%%python a.b", None)
+    ret = asyncio.run(kernel.do_execute("?%%python a.b", None))
     assert ret["payload"][0]["data"]["text/plain"] == 'No help available for "a.b"'
 
-    ret = kernel.do_execute("??%%python oct", None)
+    ret = asyncio.run(kernel.do_execute("??%%python oct", None))
     assert (
         "Return the octal representation of an integer"
         in ret["payload"][0]["data"]["text/plain"]
@@ -89,6 +94,6 @@ def test_python_magic4() -> None:
 
 def test_python_magic5() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%python print('hello')")
+    asyncio.run(kernel.do_execute("%python print('hello')"))
 
     assert "hello" in get_log_text(kernel)

--- a/tests/magics/test_reload_magics_magic.py
+++ b/tests/magics/test_reload_magics_magic.py
@@ -1,9 +1,11 @@
+import asyncio
+
 from tests.utils import get_kernel, get_log_text
 
 
 def test_reload_magics_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%reload_magics")
+    asyncio.run(kernel.do_execute("%reload_magics"))
     text = get_log_text(kernel)
 
     for item in "%cd %connect_info %download %edit %help %html %install_magic %javascript %kernel %kx %latex %load %lsmagic %magic %parallel %plot %pmap %px %python %reload_magics %restart %run %shell %macro %%debug %%file %%help %%html %%javascript %%kx %%latex %%processing %%px %%python %%shell %%show %%macro %%time".split():

--- a/tests/magics/test_restart_magic.py
+++ b/tests/magics/test_restart_magic.py
@@ -1,12 +1,14 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 
 def test_restart_magic() -> None:
     kernel = get_kernel(EvalKernel)
 
-    kernel.do_execute("a=1")
-    kernel.do_execute("%restart")
-    kernel.do_execute("a")
+    asyncio.run(kernel.do_execute("a=1"))
+    asyncio.run(kernel.do_execute("%restart"))
+    asyncio.run(kernel.do_execute("a"))
 
     text = get_log_text(kernel)
     assert "NameError" in text

--- a/tests/magics/test_run_magic.py
+++ b/tests/magics/test_run_magic.py
@@ -1,16 +1,22 @@
+import asyncio
+
 from tests.utils import EvalKernel, clear_log_text, get_kernel, get_log_text
 
 
 def test_run_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%%run %s" % __file__.replace(".pyc", ".py"))
-    kernel.do_execute("TEST")
+    asyncio.run(kernel.do_execute("%%run %s" % __file__.replace(".pyc", ".py")))
+    asyncio.run(kernel.do_execute("TEST"))
     text = get_log_text(kernel)
     assert "42" in text, "Didn't run this file"
 
     clear_log_text(kernel)
-    kernel.do_execute("%%run --language python %s" % __file__.replace(".pyc", ".py"))
-    kernel.do_execute("TEST")
+    asyncio.run(
+        kernel.do_execute(
+            "%%run --language python %s" % __file__.replace(".pyc", ".py")
+        )
+    )
+    asyncio.run(kernel.do_execute("TEST"))
     text = get_log_text(kernel)
     assert "42" in text, "Didn't run this file"
 

--- a/tests/magics/test_scheme_magic.py
+++ b/tests/magics/test_scheme_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 
 import pytest
@@ -13,14 +14,14 @@ pytestmark = pytest.mark.skipif(
 
 def test_scheme_line_magic_expression() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%scheme (+ 1 2)", None)
+    asyncio.run(kernel.do_execute("%scheme (+ 1 2)", None))
     magic = kernel.line_magics["scheme"]
     assert magic.retval == 3
 
 
 def test_scheme_line_magic_define() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%scheme (define x 42)", None)
+    asyncio.run(kernel.do_execute("%scheme (define x 42)", None))
     magic = kernel.line_magics["scheme"]
     # define statements return a void Symbol in calysto_scheme, not None
     from calysto_scheme import scheme as cs
@@ -30,7 +31,7 @@ def test_scheme_line_magic_define() -> None:
 
 def test_scheme_cell_magic() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%%scheme\n(+ 10 32)", None)
+    asyncio.run(kernel.do_execute("%%scheme\n(+ 10 32)", None))
     magic = kernel.cell_magics["scheme"]
     assert magic.retval == 42
     assert not magic.evaluate
@@ -38,7 +39,7 @@ def test_scheme_cell_magic() -> None:
 
 def test_scheme_cell_magic_multiline() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%%scheme\n(define x 10)\n(+ x 5)", None)
+    asyncio.run(kernel.do_execute("%%scheme\n(define x 10)\n(+ x 5)", None))
     magic = kernel.cell_magics["scheme"]
     assert magic.retval == 15
 
@@ -46,14 +47,14 @@ def test_scheme_cell_magic_multiline() -> None:
 def test_scheme_cell_magic_eval_output() -> None:
     kernel = get_kernel()
     # -e flag: Scheme result is used as code for the host kernel
-    kernel.do_execute('%%scheme -e\n"1 + 2"', None)
+    asyncio.run(kernel.do_execute('%%scheme -e\n"1 + 2"', None))
     magic = kernel.cell_magics["scheme"]
     assert magic.evaluate
 
 
 def test_scheme_cell_magic_empty() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%%scheme\n  ", None)
+    asyncio.run(kernel.do_execute("%%scheme\n  ", None))
     magic = kernel.cell_magics["scheme"]
     # Whitespace-only cell: nothing is evaluated, retval stays None
     assert magic.retval is None

--- a/tests/magics/test_set_get_magic.py
+++ b/tests/magics/test_set_get_magic.py
@@ -1,25 +1,27 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 
 def test_set_get_int_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%set x 42")
-    kernel.do_execute("%get x")
+    asyncio.run(kernel.do_execute("%set x 42"))
+    asyncio.run(kernel.do_execute("%get x"))
     text = get_log_text(kernel)
     assert "42" in text, text
 
 
 def test_set_get_list_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%set variable [1., 2., 3., 4.]")
-    kernel.do_execute("%get variable")
+    asyncio.run(kernel.do_execute("%set variable [1., 2., 3., 4.]"))
+    asyncio.run(kernel.do_execute("%get variable"))
     text = get_log_text(kernel)
     assert "[1.0, 2.0, 3.0, 4.0]" in text, text
 
 
 def test_set_get_range_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("%set variable range(2)")
-    kernel.do_execute("%get variable")
+    asyncio.run(kernel.do_execute("%set variable range(2)"))
+    asyncio.run(kernel.do_execute("%get variable"))
     text = get_log_text(kernel)
     assert "range(0, 2)" in text, text

--- a/tests/magics/test_shell_magic.py
+++ b/tests/magics/test_shell_magic.py
@@ -1,4 +1,5 @@
 # force locale to C to get consistent error messages
+import asyncio
 import os
 import sys
 
@@ -37,11 +38,11 @@ def test_shell_magic() -> None:
 )
 def test_shell_magic2() -> None:
     kernel = get_kernel()
-    kernel.do_execute('!cat "%s"' % __file__, False)
+    asyncio.run(kernel.do_execute('!cat "%s"' % __file__, False))
     log_text = get_log_text(kernel)
     assert "metakernel.py" in log_text
 
-    kernel.do_execute('!!\necho "hello"\necho "goodbye"', None)
+    asyncio.run(kernel.do_execute('!!\necho "hello"\necho "goodbye"', None))
     log_text = get_log_text(kernel)
     assert '"hello"' in log_text
     assert '"goodbye"' in log_text
@@ -49,7 +50,7 @@ def test_shell_magic2() -> None:
 
 def test_shell_magic3() -> None:
     kernel = get_kernel()
-    kernel.do_execute("!lalkjds")
+    asyncio.run(kernel.do_execute("!lalkjds"))
     text = get_log_text(kernel)
     # POSIX: ": command not found", Windows: "is not recognized as the name of a cmdlet"
     assert ": command not found" in text or "is not recognized" in text, text

--- a/tests/magics/test_show_magic.py
+++ b/tests/magics/test_show_magic.py
@@ -1,18 +1,24 @@
+import asyncio
+
 from tests.utils import EvalKernel, get_kernel
 
 
 def test_show_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    results = kernel.do_execute("""%%show
+    results = asyncio.run(
+        kernel.do_execute("""%%show
 Welcome to the big show!
 """)
+    )
     text = results["payload"][0]["data"]["text/plain"]
     assert "Welcome to the big show!" in text, text
 
-    results = kernel.do_execute("""%%show --output
+    results = asyncio.run(
+        kernel.do_execute("""%%show --output
 # Welcome to the big show!
 retval = "This is a test"
 """)
+    )
     text = results["payload"][0]["data"]["text/plain"]
     assert "Welcome to the big show!" not in text, text
     assert "This is a test" in text, text

--- a/tests/magics/test_time_magic.py
+++ b/tests/magics/test_time_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 
 from tests.utils import EvalKernel, get_kernel, get_log_text
@@ -5,9 +6,11 @@ from tests.utils import EvalKernel, get_kernel, get_log_text
 
 def test_time_magic() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("""%%time
+    asyncio.run(
+        kernel.do_execute("""%%time
 x = 1
 """)
+    )
     text = get_log_text(kernel)
 
     assert (

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 import sys
@@ -54,7 +55,7 @@ def test_help() -> None:
     resp = kernel.get_help_on("%shell", 0)
     assert "run the line as a shell command" in resp
 
-    resp = kernel.do_execute("%cd?", False)
+    resp = asyncio.run(kernel.do_execute("%cd?", False))
     assert (
         "change current directory of session"
         in resp["payload"][0]["data"]["text/plain"]
@@ -125,8 +126,8 @@ def test_ls_path_complete() -> None:
 
 def test_history() -> None:
     kernel = get_kernel()
-    kernel.do_execute("!ls", False)
-    kernel.do_execute("%cd ~", False)
+    asyncio.run(kernel.do_execute("!ls", False))
+    asyncio.run(kernel.do_execute("%cd ~", False))
     kernel.do_shutdown(False)
 
     with open(kernel.hist_file, "rb") as fid:
@@ -143,12 +144,12 @@ def test_history() -> None:
 
 def test_sticky_magics() -> None:
     kernel = get_kernel()
-    kernel.do_execute("%%%html\nhello", None)
+    asyncio.run(kernel.do_execute("%%%html\nhello", None))
     text = get_log_text(kernel)
 
     assert "html added to session magics" in text
-    kernel.do_execute("<b>hello</b>", None)
-    kernel.do_execute("%%%html", None)
+    asyncio.run(kernel.do_execute("<b>hello</b>", None))
+    asyncio.run(kernel.do_execute("%%%html", None))
     text = get_log_text(kernel)
     assert text.count("Display Data") == 2
     assert "html removed from session magics" in text
@@ -156,7 +157,7 @@ def test_sticky_magics() -> None:
 
 def test_shell_partial_quote() -> None:
     kernel = get_kernel()
-    kernel.do_execute('%cd "/home/', False)
+    asyncio.run(kernel.do_execute('%cd "/home/', False))
     text = get_log_text(kernel)
     # POSIX: "No such file or directory: '"/home/'"
     # Windows: "[WinError 123] ... syntax is incorrect: '"/home/'"
@@ -171,9 +172,9 @@ def test_other_kernels() -> None:
             return "OK"
 
     kernel = get_kernel(SchemeKernel)
-    resp = kernel.do_execute("dir?", None)
+    resp = asyncio.run(kernel.do_execute("dir?", None))
     assert len(resp["payload"]) == 0, "should handle this, rather than using help"
-    resp = kernel.do_execute("?dir?", None)
+    resp = asyncio.run(kernel.do_execute("?dir?", None))
     assert len(resp["payload"]) == 1, "should use help"
     message = resp["payload"][0]["data"]["text/plain"]
     assert "Sorry, no help is available on 'dir?'." == message, message
@@ -226,22 +227,22 @@ def test_other_kernels() -> None:
 
 def test_do_execute_meta() -> None:
     kernel = get_kernel(EvalKernel)
-    kernel.do_execute("~~META~~: reset")
+    asyncio.run(kernel.do_execute("~~META~~: reset"))
     text = get_log_text(kernel)
     assert "RESET" in text, text
     clear_log_text(kernel)
 
-    kernel.do_execute("~~META~~: stop")
+    asyncio.run(kernel.do_execute("~~META~~: stop"))
     text = get_log_text(kernel)
     assert "STOP" in text, text
     clear_log_text(kernel)
 
-    kernel.do_execute("~~META~~: step")
+    asyncio.run(kernel.do_execute("~~META~~: step"))
     text = get_log_text(kernel)
     assert "STEP" in text, text
     clear_log_text(kernel)
 
-    kernel.do_execute("~~META~~: inspect something")
+    asyncio.run(kernel.do_execute("~~META~~: inspect something"))
     text = get_log_text(kernel)
     assert "INSPECT" in text, text
     clear_log_text(kernel)
@@ -251,7 +252,21 @@ def test_do_execute_meta2() -> None:
     kernel = get_kernel()
     for code in ["reset, stop", "step", "inspect ", "garbage"]:
         with pytest.raises(Exception):  # noqa: B017
-            kernel.do_execute("~~META~~: %s" % code)
+            asyncio.run(kernel.do_execute("~~META~~: %s" % code))
+
+
+def test_async_do_execute_direct() -> None:
+    """async do_execute_direct is awaited and its return value is handled."""
+
+    class AsyncKernel(MetaKernel):
+        async def do_execute_direct(self, code, *args, **kwargs):
+            return code.upper()
+
+    kernel = get_kernel(AsyncKernel)
+    resp = asyncio.run(kernel.do_execute("hello", False))
+    assert resp["status"] == "ok"
+    # The return value should have been stored in the kernel's _ variable
+    assert kernel.__ == "HELLO"
 
 
 def test_misc() -> None:

--- a/tests/test_process_metakernel.py
+++ b/tests/test_process_metakernel.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import pytest
@@ -14,22 +15,24 @@ pytestmark = pytest.mark.skipif(
 
 def test_process_metakernel() -> None:
     kernel = get_kernel(BashKernel)
-    kernel.do_execute('cat "%s"' % __file__, False)
+    asyncio.run(kernel.do_execute('cat "%s"' % __file__, False))
     log_text = get_log_text(kernel)
     assert "metakernel.py" in log_text, log_text
 
-    kernel.do_execute('echo "hello"\necho "goodbye"', None)
+    asyncio.run(kernel.do_execute('echo "hello"\necho "goodbye"', None))
     log_text = get_log_text(kernel)
     assert '"hello"' in log_text
     assert '"goodbye"' in log_text
 
-    kernel.do_execute("lalkjds")
+    asyncio.run(kernel.do_execute("lalkjds"))
     text = get_log_text(kernel)
     assert ": command not found" in text, text
 
     html = HTML("some html")
     kernel.Display(html)
 
-    kernel.do_execute(r'for i in {1..3};do echo -ne "$i\r"; sleep 1; done', None)
+    asyncio.run(
+        kernel.do_execute(r'for i in {1..3};do echo -ne "$i\r"; sleep 1; done', None)
+    )
     text = get_log_text(kernel)
     assert r"1\r2\r3\r" in text


### PR DESCRIPTION
Closes #336

## Summary

- `MetaKernel.do_execute` is now `async`. After calling `do_execute_direct`, the result is checked with `inspect.isawaitable()` and awaited if needed — so subclasses can define `do_execute_direct` as either a regular or `async` function.
- ipykernel's `execute_request` already handles awaitable `do_execute` (it checks `inspect.isawaitable` on the return value), so this integrates transparently with the kernel machinery.
- `install_magic` was updated to call `shell.line_shell()` directly instead of going through `do_execute`, fixing a sync-calls-async anti-pattern where a magic handler was calling the now-async `do_execute` internally.
- All test calls to `kernel.do_execute()` are wrapped with `asyncio.run()`.

## Test plan

- [x] New test `test_async_do_execute_direct` verifies that a kernel with `async def do_execute_direct` is properly awaited and its return value stored
- [x] Full test suite passes: `just test`