### PR TITLE
Convert top-level kernel methods to async

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -412,14 +412,14 @@ class MetaKernel(Kernel):
                 if inspect.isawaitable(retval):
                     retval = await retval
 
-        self.post_execute(retval, code, silent)
+        await self.post_execute(retval, code, silent)
 
         if "payload" in self.kernel_resp:
             self.kernel_resp["payload"] = self.payload
 
         return self.kernel_resp
 
-    def post_execute(self, retval: Any, code: str, silent: bool) -> None:
+    async def post_execute(self, retval: Any, code: str, silent: bool) -> None:
         """Post-execution actions
 
         Handle special kernel variables and display response if not silent.
@@ -468,7 +468,7 @@ class MetaKernel(Kernel):
                         return
                     self.send_response(self.iopub_socket, "execute_result", content)
 
-    def do_history(
+    async def do_history(
         self,
         hist_access_type: str | None,
         output: str | None,
@@ -489,7 +489,7 @@ class MetaKernel(Kernel):
             self.hist_cache = json.loads(fid.read() or "[]")
         return {"status": "ok", "history": [(None, None, h) for h in self.hist_cache]}
 
-    def do_shutdown(self, restart: bool) -> dict[str, Any]:
+    async def do_shutdown(self, restart: bool) -> dict[str, Any]:
         """
         Shut down the app gracefully, saving history.
 
@@ -505,7 +505,7 @@ class MetaKernel(Kernel):
             self.Print("Done!")
         return {"status": "ok", "restart": restart}
 
-    def do_is_complete(self, code: str) -> dict[str, str]:
+    async def do_is_complete(self, code: str) -> dict[str, str]:
         """
         Given code as string, returns dictionary with 'status' representing
         whether code is ready to evaluate. Possible values for status are:
@@ -537,7 +537,7 @@ class MetaKernel(Kernel):
         else:
             return {"status": "incomplete"}
 
-    def do_complete(self, code: str, cursor_pos: int) -> dict[str, Any]:
+    async def do_complete(self, code: str, cursor_pos: int) -> dict[str, Any]:
         """Handle code completion for the kernel.
 
         https://jupyter-client.readthedocs.io/en/stable/messaging.html#completion
@@ -599,7 +599,7 @@ class MetaKernel(Kernel):
 
         return content
 
-    def do_inspect(
+    async def do_inspect(
         self, code: str, cursor_pos: int, detail_level: int = 0, omit_sections: Any = ()
     ) -> dict[str, Any] | None:
         """Object introspection.
@@ -626,7 +626,7 @@ class MetaKernel(Kernel):
 
         return content
 
-    def clear_output(self, wait: bool = False) -> None:
+    async def clear_output(self, wait: bool = False) -> None:
         """Clear the output of the kernel."""
         self.send_response(self.iopub_socket, "clear_output", {"wait": wait})
 
@@ -638,7 +638,7 @@ class MetaKernel(Kernel):
         See https://ipython.readthedocs.io/en/stable/config/integrating.html?highlight=display#rich-display
         """
         if kwargs.get("clear_output"):
-            self.clear_output(wait=True)
+            self.send_response(self.iopub_socket, "clear_output", {"wait": True})
 
         for item in objects:
             if Widget and isinstance(item, Widget):

--- a/metakernel/display.py
+++ b/metakernel/display.py
@@ -19,6 +19,7 @@ def clear_output(*args: Any, **kwargs: Any) -> None:
 
     kernel = get_metakernel()
     if kernel:
-        kernel.clear_output(*args, **kwargs)
+        wait = kwargs.get("wait", False)
+        kernel.send_response(kernel.iopub_socket, "clear_output", {"wait": wait})
     else:
         ipclear_output(*args, **kwargs)  # type:ignore[no-untyped-call]

--- a/metakernel/magics/restart_magic.py
+++ b/metakernel/magics/restart_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
+
 from metakernel import Magic
 
 
@@ -17,7 +19,14 @@ class RestartMagic(Magic):
 
         Note that you will lose all computed values.
         """
-        self.kernel.do_shutdown(True)
+        kernel = self.kernel
+        if kernel.hist_file:
+            with open(kernel.hist_file, "w") as fid:
+                json.dump(kernel.hist_cache[-kernel.max_hist_cache :], fid)
+        kernel.Print("Restarting kernel...")
+        kernel.restart_kernel()
+        kernel.reload_magics()
+        kernel.Print("Done!")
 
 
 def register_magics(kernel) -> None:

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -176,7 +176,7 @@ class ProcessMetaKernel(MetaKernel):
         """
         raise NotImplementedError
 
-    def do_shutdown(self, restart: bool) -> dict[str, str]:
+    async def do_shutdown(self, restart: bool) -> dict[str, str]:
         """
         Shut down the app gracefully, saving history.
         """
@@ -185,7 +185,7 @@ class ProcessMetaKernel(MetaKernel):
                 self.wrapper.terminate()
             except Exception as e:
                 self.Error(str(e))
-        return super().do_shutdown(restart)
+        return await super().do_shutdown(restart)
 
     def restart_kernel(self) -> None:
         """Restart the kernel"""

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -94,7 +94,13 @@ class ProcessMetaKernel(MetaKernel):
             output = wrapper.interrupt()
         except EOF:
             self.Print(child.before)
-            self.do_shutdown(True)
+            if self.wrapper is not None:
+                try:
+                    self.wrapper.terminate()
+                except Exception:
+                    pass
+            self.restart_kernel()
+            self.reload_magics()
             error = RuntimeError("End of File")
             tb = "End of File"
         except Exception as e:

--- a/metakernel_python/metakernel_python/__init__.py
+++ b/metakernel_python/metakernel_python/__init__.py
@@ -64,7 +64,7 @@ class MetaKernelPython(MetaKernel):
         python_magic = self.line_magics["python"]
         return python_magic.get_help_on(info, level, none_on_fail)  # type:ignore[no-any-return]
 
-    def do_is_complete(self, code: str) -> dict[str, Any]:
+    async def do_is_complete(self, code: str) -> dict[str, Any]:
         status, indent_spaces = self.transformer_manager.check_complete(code)
         r = {"status": status}
         if status == "incomplete":

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -8,7 +8,7 @@ def test_python_magic() -> None:
     kernel = get_kernel()
 
     text = "%python imp"
-    comp = kernel.do_complete(text, len(text))
+    comp = asyncio.run(kernel.do_complete(text, len(text)))
 
     assert "import" in comp["matches"]
 

--- a/tests/magics/test_shell_magic.py
+++ b/tests/magics/test_shell_magic.py
@@ -19,7 +19,7 @@ def test_shell_magic() -> None:
     kernel = get_kernel()
 
     text = "%shell ech"
-    comp = kernel.do_complete(text, len(text))
+    comp = asyncio.run(kernel.do_complete(text, len(text)))
 
     assert "echo" in comp["matches"]
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,3 +1,4 @@
+import unittest.mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,26 +68,24 @@ def test_display_without_kernel_multiple_args() -> None:
 # --- clear_output() ---
 
 
-def test_clear_output_with_kernel_calls_kernel_clear_output() -> None:
+def test_clear_output_with_kernel_calls_send_response() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    mock_clear = MagicMock()
-    kernel.clear_output = mock_clear  # type: ignore[method-assign]
-
-    display_module.clear_output()
-
-    mock_clear.assert_called_once_with()
+    with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+        display_module.clear_output()
+    mock_send.assert_called_once_with(
+        kernel.iopub_socket, "clear_output", {"wait": False}
+    )
 
 
 def test_clear_output_with_kernel_passes_wait() -> None:
     kernel = get_kernel()
     MetaKernel.meta_kernel = kernel
-    mock_clear = MagicMock()
-    kernel.clear_output = mock_clear  # type: ignore[method-assign]
-
-    display_module.clear_output(wait=True)
-
-    mock_clear.assert_called_once_with(wait=True)
+    with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+        display_module.clear_output(wait=True)
+    mock_send.assert_called_once_with(
+        kernel.iopub_socket, "clear_output", {"wait": True}
+    )
 
 
 def test_clear_output_without_kernel_calls_ipclear_output() -> None:

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -69,24 +69,24 @@ def test_help() -> None:
 
 def test_complete() -> None:
     kernel = get_kernel()
-    comp = kernel.do_complete("%connect_", len("%connect_"))
+    comp = asyncio.run(kernel.do_complete("%connect_", len("%connect_")))
     assert comp["matches"] == ["%connect_info"], str(comp["matches"])
 
-    comp = kernel.do_complete("%%fil", len("%%fil"))
+    comp = asyncio.run(kernel.do_complete("%%fil", len("%%fil")))
     assert comp["matches"] == ["%%file"], str(comp["matches"])
 
-    comp = kernel.do_complete("%%", len("%%"))
+    comp = asyncio.run(kernel.do_complete("%%", len("%%")))
     assert "%%file" in comp["matches"]
     assert "%%html" in comp["matches"]
 
 
 def test_inspect() -> None:
     kernel = get_kernel()
-    kernel.do_inspect("%lsmagic", len("%lsmagic"))
+    asyncio.run(kernel.do_inspect("%lsmagic", len("%lsmagic")))
     log_text = get_log_text(kernel)
     assert "list the current line and cell magics" in log_text
 
-    kernel.do_inspect("%lsmagic ", len("%lsmagic") + 1)
+    asyncio.run(kernel.do_inspect("%lsmagic ", len("%lsmagic") + 1))
 
 
 @pytest.mark.skipif(
@@ -94,7 +94,7 @@ def test_inspect() -> None:
 )
 def test_path_complete() -> None:
     kernel = get_kernel()
-    comp = kernel.do_complete("~/.ipytho", len("~/.ipytho"))
+    comp = asyncio.run(kernel.do_complete("~/.ipytho", len("~/.ipytho")))
     assert comp["matches"] == ["ipython/"]
 
     paths = [
@@ -102,7 +102,7 @@ def test_path_complete() -> None:
     ]
 
     for path in paths:
-        comp = kernel.do_complete(path, len(path) - 1)
+        comp = asyncio.run(kernel.do_complete(path, len(path) - 1))
 
         if os.path.isdir(path):
             path = path.split()[-1]
@@ -120,7 +120,7 @@ def test_path_complete() -> None:
 )
 def test_ls_path_complete() -> None:
     kernel = get_kernel()
-    comp = kernel.do_complete("! ls ~/.ipytho", len("! ls ~/.ipytho"))
+    comp = asyncio.run(kernel.do_complete("! ls ~/.ipytho", len("! ls ~/.ipytho")))
     assert comp["matches"] == ["ipython/"], comp
 
 
@@ -128,7 +128,7 @@ def test_history() -> None:
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("!ls", False))
     asyncio.run(kernel.do_execute("%cd ~", False))
-    kernel.do_shutdown(False)
+    asyncio.run(kernel.do_shutdown(False))
 
     with open(kernel.hist_file, "rb") as fid:
         text = fid.read().decode("utf-8", "replace")
@@ -137,7 +137,7 @@ def test_history() -> None:
     assert "%cd" in text
 
     kernel = get_kernel()
-    kernel.do_history(None, None, None)
+    asyncio.run(kernel.do_history(None, None, None))
     assert "!ls" in "".join(kernel.hist_cache)
     assert "%cd ~"
 
@@ -179,19 +179,19 @@ def test_other_kernels() -> None:
     message = resp["payload"][0]["data"]["text/plain"]
     assert "Sorry, no help is available on 'dir?'." == message, message
 
-    content = kernel.do_inspect("dir", len("dir"))
+    content = asyncio.run(kernel.do_inspect("dir", len("dir")))
     assert content is not None
     assert content["status"] == "aborted" and not content["found"], (
         "do_inspect should abort, and be not found"
     )
 
-    content = kernel.do_inspect("len(dir", len("len(dir"))
+    content = asyncio.run(kernel.do_inspect("len(dir", len("len(dir")))
     assert content is not None
     assert content["status"] == "aborted" and not content["found"], (
         "do_inspect should abort, and be not found"
     )
 
-    content = kernel.do_inspect("(dir", len("(dir"))
+    content = asyncio.run(kernel.do_inspect("(dir", len("(dir")))
     assert content is not None
     assert content["status"] == "aborted" and not content["found"], (
         "do_inspect should abort, and be not found"
@@ -203,21 +203,21 @@ def test_other_kernels() -> None:
             "Help is available on '%s'." % info["obj"]
         )
     )
-    content = kernel.do_inspect("dir", len("dir"))
+    content = asyncio.run(kernel.do_inspect("dir", len("dir")))
     assert content is not None
     message = content["data"]["text/plain"]
     match = re.match("Help is available on '(.*)'", message)
     assert match is not None
     assert match.groups()[0] == "dir", message + " for 'dir'"
 
-    content = kernel.do_inspect("len(dir", len("len(dir"))
+    content = asyncio.run(kernel.do_inspect("len(dir", len("len(dir")))
     assert content is not None
     message = content["data"]["text/plain"]
     match = re.match("Help is available on '(.*)'", message)
     assert match is not None
     assert match.groups()[0] == "dir", message + " for 'dir'"
 
-    content = kernel.do_inspect("(dir", len("(dir"))
+    content = asyncio.run(kernel.do_inspect("(dir", len("(dir")))
     assert content is not None
     message = content["data"]["text/plain"]
     match = re.match("Help is available on '(.*)'", message)
@@ -292,10 +292,10 @@ def test_misc() -> None:
     assert "hello(XXX)" in text, text
     kernel.restart_kernel()
 
-    ret = kernel.do_is_complete("hello\n")
+    ret = asyncio.run(kernel.do_is_complete("hello\n"))
     assert ret == {"status": "complete"}
 
-    assert kernel.do_inspect("hello", 10) is None
+    assert asyncio.run(kernel.do_inspect("hello", 10)) is None
 
 
 def test_error_display_string() -> None:
@@ -510,7 +510,7 @@ class TestPostExecuteSilent:
     def test_send_response_not_called_for_normal_retval(self) -> None:
         kernel = get_kernel(EvalKernel)
         with unittest.mock.patch.object(kernel, "send_response") as mock_send:
-            kernel.post_execute("result", "code", silent=True)
+            asyncio.run(kernel.post_execute("result", "code", silent=True))
         mock_send.assert_not_called()
 
     def test_send_response_not_called_for_exception_wrapper(self) -> None:
@@ -518,21 +518,21 @@ class TestPostExecuteSilent:
         kernel.kernel_resp = {"status": "ok"}
         exc = ExceptionWrapper("ValueError", "bad", ["traceback line"])
         with unittest.mock.patch.object(kernel, "send_response") as mock_send:
-            kernel.post_execute(exc, "code", silent=True)
+            asyncio.run(kernel.post_execute(exc, "code", silent=True))
         mock_send.assert_not_called()
 
     def test_send_response_not_called_for_none_retval(self) -> None:
         kernel = get_kernel(EvalKernel)
         with unittest.mock.patch.object(kernel, "send_response") as mock_send:
-            kernel.post_execute(None, "code", silent=True)
+            asyncio.run(kernel.post_execute(None, "code", silent=True))
         mock_send.assert_not_called()
 
     def test_history_variables_updated(self) -> None:
         # post_execute writes back _ii and _iii as Python attrs; _i goes only
         # through set_variable into the kernel env.
         kernel = get_kernel(EvalKernel)
-        kernel.post_execute(None, "first", silent=True)
-        kernel.post_execute(None, "second", silent=True)
+        asyncio.run(kernel.post_execute(None, "first", silent=True))
+        asyncio.run(kernel.post_execute(None, "second", silent=True))
         assert kernel._ii == "second"
         assert kernel._iii == "first"
 
@@ -540,41 +540,45 @@ class TestPostExecuteSilent:
         # post_execute writes back __ as a Python attr; _ goes only through
         # set_variable into the kernel env.
         kernel = get_kernel(EvalKernel)
-        kernel.post_execute(42, "code", silent=True)
+        asyncio.run(kernel.post_execute(42, "code", silent=True))
         assert kernel.__ == 42
 
     def test_error_status_set_for_exception_wrapper(self) -> None:
         kernel = get_kernel(EvalKernel)
         kernel.kernel_resp = {"status": "ok"}
         exc = ExceptionWrapper("NameError", "x not defined", [])
-        kernel.post_execute(exc, "code", silent=True)
+        asyncio.run(kernel.post_execute(exc, "code", silent=True))
         assert kernel.kernel_resp["status"] == "error"
 
 
 class TestDoIsComplete:
     def test_regular_code_ending_with_newline_is_complete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("x = 1\n") == {"status": "complete"}
+        assert asyncio.run(kernel.do_is_complete("x = 1\n")) == {"status": "complete"}
 
     def test_regular_code_without_newline_is_incomplete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("x = 1") == {"status": "incomplete"}
+        assert asyncio.run(kernel.do_is_complete("x = 1")) == {"status": "incomplete"}
 
     def test_magic_ending_with_newline_is_complete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("%cd /tmp\n") == {"status": "complete"}
+        assert asyncio.run(kernel.do_is_complete("%cd /tmp\n")) == {
+            "status": "complete"
+        }
 
     def test_magic_without_newline_is_incomplete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("%cd /tmp") == {"status": "incomplete"}
+        assert asyncio.run(kernel.do_is_complete("%cd /tmp")) == {
+            "status": "incomplete"
+        }
 
     def test_empty_string_is_incomplete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("") == {"status": "incomplete"}
+        assert asyncio.run(kernel.do_is_complete("")) == {"status": "incomplete"}
 
     def test_bare_newline_is_complete(self) -> None:
         kernel = get_kernel()
-        assert kernel.do_is_complete("\n") == {"status": "complete"}
+        assert asyncio.run(kernel.do_is_complete("\n")) == {"status": "complete"}
 
 
 class TestPrintWriteErrorRedirectToLog:

--- a/tests/test_process_metakernel_classes.py
+++ b/tests/test_process_metakernel_classes.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -194,14 +195,14 @@ def test_do_shutdown_calls_terminate_on_wrapper() -> None:
     kernel = get_kernel(_TestKernel)
     mock_wrapper = MagicMock()
     kernel.wrapper = mock_wrapper
-    kernel.do_shutdown(False)
+    asyncio.run(kernel.do_shutdown(False))
     mock_wrapper.terminate.assert_called_once()
 
 
 def test_do_shutdown_with_no_wrapper_does_not_raise() -> None:
     kernel = get_kernel(_TestKernel)
     kernel.wrapper = None
-    kernel.do_shutdown(False)  # should not raise
+    asyncio.run(kernel.do_shutdown(False))  # should not raise
 
 
 def test_restart_kernel_replaces_wrapper() -> None:


### PR DESCRIPTION
## Summary

- `post_execute`, `do_history`, `do_shutdown`, `do_is_complete`, `do_complete`, `do_inspect`, and `clear_output` are now `async def`, allowing subclasses to override them with async implementations
- `do_execute` now `await`s `post_execute`
- `Display` inlines the `send_response` call instead of awaiting `clear_output`, avoiding the need to make `Display` async
- `ProcessMetaKernel.do_shutdown` is updated to `async`, awaiting `super().do_shutdown()`
- `restart_magic` calls `restart_kernel()`/`reload_magics()` directly instead of the now-async `do_shutdown` (same pattern used in `install_magic` for `do_execute`)
- All affected test call sites wrapped with `asyncio.run()`
