### PR TITLE
Allow kernel-specific behavior methods to be async

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -360,7 +360,7 @@ class MetaKernel(Kernel):
                 level = 0
             else:
                 level = 1
-            text = self.get_help_on(code, level)
+            text = await self.get_help_on(code, level)
             if text:
                 content = {
                     "start_line_number": 0,
@@ -384,7 +384,7 @@ class MetaKernel(Kernel):
             magic = None
             prefixes = (self.magic_prefixes["shell"], self.magic_prefixes["magic"])
             while code.startswith(prefixes):
-                magic = self.get_magic(code)
+                magic = await self.get_magic(code)
                 if magic is not None:
                     stack.append(magic)
                     code = str(magic.get_code())
@@ -397,6 +397,8 @@ class MetaKernel(Kernel):
             if (magic is None or magic.evaluate) and code.strip() != "":
                 if code.startswith("~~META~~:"):
                     retval = self.do_execute_meta(code[9:].strip())
+                    if inspect.isawaitable(retval):
+                        retval = await retval
                 else:
                     retval = self.do_execute_direct(code)
                     if inspect.isawaitable(retval):
@@ -407,6 +409,8 @@ class MetaKernel(Kernel):
         else:
             if code.startswith("~~META~~:"):
                 retval = self.do_execute_meta(code[9:].strip())
+                if inspect.isawaitable(retval):
+                    retval = await retval
             else:
                 retval = self.do_execute_direct(code)
                 if inspect.isawaitable(retval):
@@ -424,20 +428,26 @@ class MetaKernel(Kernel):
 
         Handle special kernel variables and display response if not silent.
         """
+
+        async def _sv(name: str, value: Any) -> None:
+            r = self.set_variable(name, value)
+            if inspect.isawaitable(r):
+                await r
+
         # Handle in's
-        self.set_variable("_iii", self._iii)
-        self.set_variable("_ii", self._ii)
-        self.set_variable("_i", code)
-        self.set_variable("_i" + str(self.execution_count), code)
+        await _sv("_iii", self._iii)
+        await _sv("_ii", self._ii)
+        await _sv("_i", code)
+        await _sv("_i" + str(self.execution_count), code)
         self._iii = self._ii
         self._ii = code
         if retval is not None:
             # --------------------------------------
             # Handle out's (only when non-null)
-            self.set_variable("___", self.___)
-            self.set_variable("__", self.__)
-            self.set_variable("_", retval)
-            self.set_variable("_" + str(self.execution_count), retval)
+            await _sv("___", self.___)
+            await _sv("__", self.__)
+            await _sv("_", retval)
+            await _sv("_" + str(self.execution_count), retval)
             self.___ = self.__
             self.__ = retval
             self.log.debug(retval)
@@ -500,7 +510,9 @@ class MetaKernel(Kernel):
                 json.dump(self.hist_cache[-self.max_hist_cache :], fid)
         if restart:
             self.Print("Restarting kernel...")
-            self.restart_kernel()
+            retval = self.restart_kernel()
+            if inspect.isawaitable(retval):
+                await retval
             self.reload_magics()
             self.Print("Done!")
         return {"status": "ok", "restart": restart}
@@ -585,7 +597,10 @@ class MetaKernel(Kernel):
                         info["obj"] = pre + info["obj"]
 
         else:
-            matches.extend(self.get_completions(info))
+            completions = self.get_completions(info)
+            if inspect.isawaitable(completions):
+                completions = await completions
+            matches.extend(completions)
 
         if info["full_obj"] and len(info["full_obj"]) > len(info["obj"]):
             new_list = [m for m in matches if m.startswith(info["full_obj"])]
@@ -610,7 +625,7 @@ class MetaKernel(Kernel):
             return None
 
         content = {"status": "aborted", "data": {}, "found": False, "metadata": {}}
-        docstring = self.get_help_on(
+        docstring = await self.get_help_on(
             code, detail_level, none_on_fail=True, cursor_pos=cursor_pos
         )
 
@@ -793,29 +808,29 @@ class MetaKernel(Kernel):
         if self.session:
             super().send_response(*args, **kwargs)  # type:ignore[no-untyped-call]
 
-    def call_magic(self, line: str) -> Magic:
+    async def call_magic(self, line: str) -> Magic:
         """
         Given an line, such as "%download http://example.com/", parse
         and execute magic.
         """
-        return self.get_magic(line)
+        return await self.get_magic(line)
 
-    def get_magic(self, text: str) -> Magic:
+    async def get_magic(self, text: str) -> Magic:
         ## FIXME: Bad name, use call_magic instead.
         # if first line matches a magic,
         # call magic.call_magic() and return magic object
         info = self.parse_code(text)
         magic = self.line_magics["magic"]
-        return magic.get_magic(info)  # type:ignore[no-any-return]
+        return await magic.get_magic(info)  # type:ignore[no-any-return]
 
-    def get_magic_args(self, text: str) -> Magic:
+    async def get_magic_args(self, text: str) -> Magic:
         # if first line matches a magic,
         # call magic.call_magic() and return magic args
         info = self.parse_code(text)
         magic = self.line_magics["magic"]
-        return magic.get_magic(info, get_args=True)  # type:ignore[no-any-return]
+        return await magic.get_magic(info, get_args=True)  # type:ignore[no-any-return]
 
-    def get_help_on(
+    async def get_help_on(
         self,
         expr: str,
         level: int = 0,
@@ -824,7 +839,7 @@ class MetaKernel(Kernel):
     ) -> Any:
         """Get help for an expression using the help magic."""
         help_magic = self.line_magics["help"]
-        return help_magic.get_text_help_on(expr, level, none_on_fail, cursor_pos)
+        return await help_magic.get_text_help_on(expr, level, none_on_fail, cursor_pos)
 
     def parse_code(
         self, code: str, cursor_start: int = 0, cursor_end: int = -1

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -70,7 +70,7 @@ class Magic:
 
         return (args, kwargs, old_args)
 
-    def call_magic(self, mtype: str, name: str, code: str, args: Any) -> Magic:
+    async def call_magic(self, mtype: str, name: str, code: str, args: Any) -> Magic:
         self.code = code
         old_args = args
         mtype = mtype.replace("sticky", "cell")
@@ -94,9 +94,13 @@ class Magic:
 
         try:
             try:
-                func(*args, **kwargs)
+                retval = func(*args, **kwargs)
+                if inspect.isawaitable(retval):
+                    await retval
             except TypeError:
-                func(old_args)
+                retval = func(old_args)
+                if inspect.isawaitable(retval):
+                    await retval
         except Exception as exc:
             msg = f"Error in calling magic '{name}' on {mtype}:\n    {exc!s}\n    args: {args}\n    kwargs: {kwargs}"
             self.kernel.Error(msg)

--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -361,8 +361,8 @@ def register_ipython_magics() -> None:
 
     @register_line_magic
     @add_docs(magic.line_activity.__doc__)
-    def activity(line):
-        kernel.call_magic("%activity " + line)
+    async def activity(line):
+        await kernel.call_magic("%activity " + line)
 
     @register_cell_magic  # type: ignore[no-redef]
     @add_docs(magic.cell_activity.__doc__)

--- a/metakernel/magics/blockly_magic.py
+++ b/metakernel/magics/blockly_magic.py
@@ -120,8 +120,8 @@ def register_ipython_magics() -> None:
     kernel.line_magics["blockly"] = magic
 
     @register_line_magic
-    def blockly(line):
+    async def blockly(line):
         """
         Use the blockly code visualizer and generator.
         """
-        kernel.call_magic("%blockly " + line)
+        await kernel.call_magic("%blockly " + line)

--- a/metakernel/magics/debug_magic.py
+++ b/metakernel/magics/debug_magic.py
@@ -2,13 +2,15 @@
 # Distributed under the terms of the Modified BSD License.
 
 
+import inspect
+
 from IPython.display import HTML, Javascript
 
 from metakernel import Magic
 
 
 class DebugMagic(Magic):
-    def cell_debug(self, dummy) -> None:
+    async def cell_debug(self, dummy) -> None:
         """
         %%debug - step through the code expression by expression
 
@@ -210,6 +212,8 @@ function reset() {
         data = self.kernel.initialize_debug(
             "\n" + self.code
         )  ## add a line so line numbers will be correct
+        if inspect.isawaitable(data):
+            data = await data
         time.sleep(0.1)
         if data.startswith("highlight: "):
             self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))

--- a/metakernel/magics/download_magic.py
+++ b/metakernel/magics/download_magic.py
@@ -73,5 +73,5 @@ def register_ipython_magics() -> None:
     kernel.line_magics["download"] = magic
 
     @register_line_magic
-    def download(line):
-        kernel.call_magic("%download " + line)
+    async def download(line):
+        await kernel.call_magic("%download " + line)

--- a/metakernel/magics/get_magic.py
+++ b/metakernel/magics/get_magic.py
@@ -1,11 +1,13 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
+
 from metakernel import Magic
 
 
 class GetMagic(Magic):
-    def line_get(self, variable) -> None:
+    async def line_get(self, variable) -> None:
         """
         %get VARIABLE - get a variable from the kernel in a Python-type.
 
@@ -14,7 +16,10 @@ class GetMagic(Magic):
         Examples:
             %get x
         """
-        self.retval = self.kernel.get_variable(variable)
+        result = self.kernel.get_variable(variable)
+        if inspect.isawaitable(result):
+            result = await result
+        self.retval = result
 
     def post_process(self, retval):
         return self.retval

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -1,6 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
 
 from metakernel import Magic
 
@@ -22,7 +23,7 @@ class HelpMagic(Magic):
             strings += [p.format(self.kernel.magic_prefixes["help"]) for p in prefixes]
         return sorted(strings)
 
-    def line_help(self, text: str) -> str | None:
+    async def line_help(self, text: str) -> str | None:
         """
         %help TEXT - get help on the given text
 
@@ -33,9 +34,9 @@ class HelpMagic(Magic):
             %help dir
 
         """
-        return self.get_text_help_on(text, 0, False)
+        return await self.get_text_help_on(text, 0, False)
 
-    def cell_help(self, text: str) -> str | None:
+    async def cell_help(self, text: str) -> str | None:
         """
         %%help TEXT - get detailed help on the given text
 
@@ -47,9 +48,9 @@ class HelpMagic(Magic):
            %%help dir
 
         """
-        return self.get_text_help_on(text, 1, False)
+        return await self.get_text_help_on(text, 1, False)
 
-    def get_text_help_on(
+    async def get_text_help_on(
         self, text: str, level: int, none_on_fail: bool = False, cursor_pos: int = -1
     ) -> str | None:
         """
@@ -69,7 +70,10 @@ class HelpMagic(Magic):
         """
         text = self._prep_text(text)
         if not text:
-            return self.kernel.get_usage()
+            usage = self.kernel.get_usage()
+            if inspect.isawaitable(usage):
+                usage = await usage
+            return usage
 
         info = self.kernel.parse_code(text, cursor_end=cursor_pos)
 
@@ -107,13 +111,19 @@ class HelpMagic(Magic):
                 return the_help
 
             elif not info["magic"]["name"]:
-                return self.kernel.get_usage()
+                usage = self.kernel.get_usage()
+                if inspect.isawaitable(usage):
+                    usage = await usage
+                return usage
 
             else:
                 return errmsg
 
         else:
-            return self.kernel.get_kernel_help_on(info, level, none_on_fail)
+            result = self.kernel.get_kernel_help_on(info, level, none_on_fail)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
 
     def _prep_text(self, text: str) -> str:
         text = text.strip()

--- a/metakernel/magics/install_magic_magic.py
+++ b/metakernel/magics/install_magic_magic.py
@@ -1,6 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
 import os
 import urllib.parse as urlparse
 import urllib.request
@@ -15,7 +16,7 @@ def download(url, filename):
 
 
 class InstallMagicMagic(Magic):
-    def line_install_magic(self, url) -> None:
+    async def line_install_magic(self, url) -> None:
         """
         %install_magic URL - download and install magic from URL
 
@@ -30,7 +31,10 @@ class InstallMagicMagic(Magic):
         # ('http', 'example.com', '/somefile.zip', '', '')
         path = parts[2]
         filename = os.path.basename(path)
-        magic_filename = os.path.join(self.kernel.get_local_magics_dir(), filename)
+        local_magics_dir = self.kernel.get_local_magics_dir()
+        if inspect.isawaitable(local_magics_dir):
+            local_magics_dir = await local_magics_dir
+        magic_filename = os.path.join(local_magics_dir, filename)
         try:
             download(url, magic_filename)
             self.kernel.Print(f"Downloaded '{magic_filename}'.")

--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -210,8 +210,8 @@ def register_ipython_magics() -> None:
     kernel.line_magics["jigsaw"] = magic
 
     @register_line_magic
-    def jigsaw(line):
+    async def jigsaw(line):
         """
         Use the Jigsaw code visualizer and generator.
         """
-        kernel.call_magic("%jigsaw " + line)
+        await kernel.call_magic("%jigsaw " + line)

--- a/metakernel/magics/macro_magic.py
+++ b/metakernel/magics/macro_magic.py
@@ -26,8 +26,15 @@ class MacroMagic(Magic):
     }
 
     def __init__(self, *args, **kwargs) -> None:
+        import asyncio
+
         super().__init__(*args, **kwargs)
-        self._load_macros()
+        coro = self._load_macros()
+        try:
+            loop = asyncio.get_running_loop()
+            self._load_macros_task = loop.create_task(coro)
+        except RuntimeError:
+            asyncio.run(coro)
 
     @option(
         "-d",
@@ -38,7 +45,7 @@ class MacroMagic(Magic):
     )
     @option("-l", "--list", action="store_true", default=False, help="list macros")
     @option("-s", "--show", action="store_true", default=False, help="show macro")
-    def line_macro(self, name, delete=False, list=False, show=False) -> None:
+    async def line_macro(self, name, delete=False, list=False, show=False) -> None:
         """
         %macro NAME - execute a macro
         %macro -l [all|learned|system] - list macros
@@ -69,7 +76,7 @@ class MacroMagic(Magic):
         elif name in self.learned:
             if delete:
                 del self.learned[name]
-                self._save_macros()
+                await self._save_macros()
             else:
                 self.code = self.code.strip()
                 if self.code:
@@ -104,9 +111,11 @@ class MacroMagic(Magic):
         else:
             self.kernel.Print(retval)
 
-    def _load_macros(self) -> None:
+    async def _load_macros(self) -> None:
         self.learned = {}
         local_macros_dir = self.kernel.get_local_magics_dir()
+        if inspect.isawaitable(local_macros_dir):
+            local_macros_dir = await local_macros_dir
         # Search all of the places there could be macros:
         files = [
             os.path.join(os.path.dirname(os.path.abspath(__file__)), "macros.json"),
@@ -124,13 +133,15 @@ class MacroMagic(Magic):
                 continue
             self.learned.update(data)
 
-    def _save_macros(self) -> None:
+    async def _save_macros(self) -> None:
         local_macros_dir = self.kernel.get_local_magics_dir()
+        if inspect.isawaitable(local_macros_dir):
+            local_macros_dir = await local_macros_dir
         filename = os.path.join(local_macros_dir, "macros.json")
         with open(filename, "w") as macros:
             macros.write(str(self.learned))
 
-    def cell_macro(self, name) -> None:
+    async def cell_macro(self, name) -> None:
         """
         %%macro NAME - learn a new macro
 
@@ -146,7 +157,7 @@ class MacroMagic(Magic):
             Ok!
         """
         self.learned[name] = self.code
-        self._save_macros()
+        await self._save_macros()
         self.evaluate = False
 
 

--- a/metakernel/magics/magic_magic.py
+++ b/metakernel/magics/magic_magic.py
@@ -52,7 +52,7 @@ class MagicMagic(Magic):
             self.kernel.Print("    " + string)
         self.kernel.Print("")
 
-    def get_magic(self, info, get_args=False) -> Any:
+    async def get_magic(self, info, get_args=False) -> Any:
 
         if not info["magic"]:
             return None
@@ -85,7 +85,7 @@ class MagicMagic(Magic):
                 minfo["type"], minfo["name"], minfo["code"], minfo["args"]
             )
         else:
-            return magic.call_magic(
+            return await magic.call_magic(
                 minfo["type"], minfo["name"], minfo["code"], minfo["args"]
             )
 

--- a/metakernel/magics/pipe_magic.py
+++ b/metakernel/magics/pipe_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
+
 from metakernel import Magic
 
 
@@ -8,7 +10,7 @@ class PipeMagic(Magic):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    def cell_pipe(self, pipe_str) -> None:
+    async def cell_pipe(self, pipe_str) -> None:
         """
         %%pipe FUNCTION1 | FUNCTION2 ...
 
@@ -29,7 +31,10 @@ class PipeMagic(Magic):
         functions = [function.strip() for function in pipe_str.split("|")]
         self.retval = self.code
         for function in functions:
-            self.retval = self.kernel.do_function_direct(function, self.retval)
+            result = self.kernel.do_function_direct(function, self.retval)
+            if inspect.isawaitable(result):
+                result = await result
+            self.retval = result
         self.evaluate = False
 
     def post_process(self, retval) -> str:

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
+
 from metakernel import Magic, option
 
 
@@ -13,7 +15,7 @@ class PlotMagic(Magic):
     @option("-r", "--resolution", action="store", help="Resolution in pixels per inch")
     @option("-w", "--width", action="store", help="Plot width in pixels")
     @option("-h", "--height", action="store", help="Plot height in pixels")
-    def line_plot(self, *args, **kwargs) -> None:
+    async def line_plot(self, *args, **kwargs) -> None:
         """
         %plot [options] backend - configure plotting for the session.
 
@@ -38,7 +40,9 @@ class PlotMagic(Magic):
             if key in kwargs and kwargs[key] is None:
                 del kwargs[key]
         self.kernel.plot_settings = kwargs
-        self.kernel.handle_plot_settings()
+        retval = self.kernel.handle_plot_settings()
+        if inspect.isawaitable(retval):
+            await retval
 
 
 def register_magics(kernel) -> None:

--- a/metakernel/magics/run_magic.py
+++ b/metakernel/magics/run_magic.py
@@ -1,6 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import inspect
 import os
 
 from metakernel import Magic, option
@@ -14,7 +15,7 @@ class RunMagic(Magic):
         default=None,
         help="use the provided language name as kernel",
     )
-    def line_run(self, filename, language=None) -> None:
+    async def line_run(self, filename, language=None) -> None:
         """
         %run [--language LANG] FILENAME - run code in filename by
            kernel
@@ -41,7 +42,9 @@ class RunMagic(Magic):
             filename = os.path.expanduser(filename)
         filename = os.path.abspath(filename)
         if language is None:
-            self.kernel.do_execute_file(filename)
+            retval = self.kernel.do_execute_file(filename)
+            if inspect.isawaitable(retval):
+                await retval
         else:
             self.code = "%%" + language + "\n" + self.code
             with open(filename) as f:

--- a/tests/magics/test_blockly_magic.py
+++ b/tests/magics/test_blockly_magic.py
@@ -70,5 +70,5 @@ def test_blockly_template_data_from_local(tmp_path) -> None:
 
 def test_blockly_help() -> None:
     kernel = get_kernel()
-    helpstr = kernel.get_help_on("%blockly")
+    helpstr = asyncio.run(kernel.get_help_on("%blockly"))
     assert "blockly" in helpstr.lower(), helpstr

--- a/tests/magics/test_brain_magic.py
+++ b/tests/magics/test_brain_magic.py
@@ -51,7 +51,7 @@ def test_brain_code_transform_structure() -> None:
 
 def test_brain_help() -> None:
     kernel = get_kernel()
-    helpstr = kernel.get_help_on("%%brain")
+    helpstr = asyncio.run(kernel.get_help_on("%%brain"))
     assert "brain" in helpstr.lower(), helpstr
 
 

--- a/tests/magics/test_conversation_magic.py
+++ b/tests/magics/test_conversation_magic.py
@@ -45,5 +45,5 @@ def test_conversation_cell_magic_embeds_id() -> None:
 
 def test_conversation_help() -> None:
     kernel = get_kernel()
-    helpstr = kernel.get_help_on("%conversation")
+    helpstr = asyncio.run(kernel.get_help_on("%conversation"))
     assert "conversation" in helpstr.lower(), helpstr

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -12,7 +12,7 @@ def test_python_magic() -> None:
 
     assert "import" in comp["matches"]
 
-    helpstr = kernel.get_help_on("%python bin")
+    helpstr = asyncio.run(kernel.get_help_on("%python bin"))
     assert "Return the binary representation of an integer" in helpstr, helpstr
 
 
@@ -49,27 +49,27 @@ def test_python_magic2() -> None:
 def test_python_magic3() -> None:
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("%%python -e\n1 + 2", None))
-    magic = kernel.get_magic("%%python")
+    magic = asyncio.run(kernel.get_magic("%%python"))
     assert magic.retval is None  # type:ignore[attr-defined]
 
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("%%python\n1 + 2", None))
-    magic = kernel.get_magic("%%python")
+    magic = asyncio.run(kernel.get_magic("%%python"))
     assert magic.retval == 3  # type:ignore[attr-defined]
 
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("%%python\n1 + 2\n2 + 3", None))
-    magic = kernel.get_magic("%%python")
+    magic = asyncio.run(kernel.get_magic("%%python"))
     assert magic.retval == 5  # type:ignore[attr-defined]
 
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("%%python\nretval = 1 + 2\n2 + 3", None))
-    magic = kernel.get_magic("%%python")
+    magic = asyncio.run(kernel.get_magic("%%python"))
     assert magic.retval == 3  # type:ignore[attr-defined]
 
     kernel = get_kernel()
     asyncio.run(kernel.do_execute("%%python\nimport math", None))
-    magic = kernel.get_magic("%%python")
+    magic = asyncio.run(kernel.get_magic("%%python"))
     assert magic.retval is None  # type:ignore[attr-defined]
 
 

--- a/tests/magics/test_scheme_magic.py
+++ b/tests/magics/test_scheme_magic.py
@@ -62,7 +62,7 @@ def test_scheme_cell_magic_empty() -> None:
 
 def test_scheme_help() -> None:
     kernel = get_kernel()
-    helpstr = kernel.get_help_on("%scheme")
+    helpstr = asyncio.run(kernel.get_help_on("%scheme"))
     assert "Scheme" in helpstr or "scheme" in helpstr, helpstr
 
 

--- a/tests/magics/test_shell_magic.py
+++ b/tests/magics/test_shell_magic.py
@@ -23,13 +23,13 @@ def test_shell_magic() -> None:
 
     assert "echo" in comp["matches"]
 
-    helpstr = kernel.get_help_on("!cat")
+    helpstr = asyncio.run(kernel.get_help_on("!cat"))
     assert "Sorry, no help" not in helpstr, helpstr
 
-    helpstr = kernel.get_help_on("%%shell cat", level=1)
+    helpstr = asyncio.run(kernel.get_help_on("%%shell cat", level=1))
     assert "Sorry, no help" not in helpstr
 
-    helpstr = kernel.get_help_on("!lkjalskdfj")
+    helpstr = asyncio.run(kernel.get_help_on("!lkjalskdfj"))
     assert "Sorry, no help" in helpstr
 
 

--- a/tests/magics/test_tutor_magic.py
+++ b/tests/magics/test_tutor_magic.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -90,5 +91,5 @@ def test_tutor_unsupported_language_raises() -> None:
 
 def test_tutor_help() -> None:
     kernel = get_kernel()
-    helpstr = kernel.get_help_on("%%tutor")
+    helpstr = asyncio.run(kernel.get_help_on("%%tutor"))
     assert "tutor" in helpstr.lower(), helpstr

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from metakernel import Magic, option
 from tests.utils import get_kernel
 
@@ -62,26 +64,26 @@ def test_option() -> None:
     assert "Options:" in d.line_dummy.__doc__  # type:ignore[operator]
     assert "--size" in d.line_dummy.__doc__  # type:ignore[operator]
 
-    ret = d.call_magic("line", "dummy", "", "hey -s400,200")
+    ret = asyncio.run(d.call_magic("line", "dummy", "", "hey -s400,200"))
     assert ret == d
     assert d.foo == "hey", d.foo
     assert d.size == (400, 200)
 
-    ret = d.call_magic("line", "dummy", "", "hey there")
+    asyncio.run(d.call_magic("line", "dummy", "", "hey there"))
     assert d.foo == "hey there"
 
-    ret = d.call_magic("line", "dummy", "", "range(1, 10)")
+    asyncio.run(d.call_magic("line", "dummy", "", "range(1, 10)"))
     # arg eval no longer evals Python raw code:
     assert d.foo == "range(1, 10)"
 
-    ret = d.call_magic("line", "dummy", "", "[1, 2, 3]")
+    asyncio.run(d.call_magic("line", "dummy", "", "[1, 2, 3]"))
     # arg eval does eval Python data structures:
     assert d.foo == [1, 2, 3]
 
-    ret = d.call_magic("line", "dummy", "", "hey -l -s400,200")
+    asyncio.run(d.call_magic("line", "dummy", "", "hey -l -s400,200"))
     assert d.size == (400, 200)
     assert d.foo == "hey -l"
 
-    ret = d.call_magic("line", "dummy", "", "hey -s -- -s400,200")
+    asyncio.run(d.call_magic("line", "dummy", "", "hey -s -- -s400,200"))
     assert d.size == (400, 200)
     assert d.foo == "hey -s"

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -44,7 +44,7 @@ def test_magics() -> None:
         assert magic in kernel.cell_magics
 
     with tempfile.NamedTemporaryFile() as ntf:
-        kernel.get_magic("%%shell ls %s" % ntf.name)
+        asyncio.run(kernel.get_magic("%%shell ls %s" % ntf.name))
         log_text = get_log_text(kernel)
         # Windows may give 8.3 short paths (RUNNER~1) vs long paths in shell output
         assert os.path.basename(ntf.name) in log_text
@@ -52,7 +52,7 @@ def test_magics() -> None:
 
 def test_help() -> None:
     kernel = get_kernel()
-    resp = kernel.get_help_on("%shell", 0)
+    resp = asyncio.run(kernel.get_help_on("%shell", 0))
     assert "run the line as a shell command" in resp
 
     resp = asyncio.run(kernel.do_execute("%cd?", False))
@@ -61,7 +61,7 @@ def test_help() -> None:
         in resp["payload"][0]["data"]["text/plain"]
     )
 
-    resp = kernel.get_help_on("what", 0)
+    resp = asyncio.run(kernel.get_help_on("what", 0))
     assert resp == "Sorry, no help is available on 'what'.", (
         "response was actually %s" % resp
     )
@@ -360,13 +360,13 @@ def test_do_execute_meta_base_direct() -> None:
 
 def test_get_magic_args_no_magic() -> None:
     kernel = get_kernel()
-    result = kernel.get_magic_args("just plain text")
+    result = asyncio.run(kernel.get_magic_args("just plain text"))
     assert result is None
 
 
 def test_get_magic_args_line_magic() -> None:
     kernel = get_kernel()
-    result: Any = kernel.get_magic_args("%cd /tmp")
+    result: Any = asyncio.run(kernel.get_magic_args("%cd /tmp"))
     assert result is not None
     args, _kwargs, _old_args = result
     assert "/tmp" in args
@@ -374,7 +374,7 @@ def test_get_magic_args_line_magic() -> None:
 
 def test_get_magic_args_no_args_magic() -> None:
     kernel = get_kernel()
-    result: Any = kernel.get_magic_args("%lsmagic")
+    result: Any = asyncio.run(kernel.get_magic_args("%lsmagic"))
     assert result is not None
     args, kwargs, _old_args = result
     assert args == []
@@ -383,7 +383,7 @@ def test_get_magic_args_no_args_magic() -> None:
 
 def test_get_magic_args_unknown_magic() -> None:
     kernel = get_kernel()
-    result = kernel.get_magic_args("%nonexistent_magic_xyz")
+    result = asyncio.run(kernel.get_magic_args("%nonexistent_magic_xyz"))
     assert result is None
 
 


### PR DESCRIPTION
## Summary

- Extends the `inspect.isawaitable` async override pattern (established for `do_execute_direct` in #337 and top-level kernel methods in #338) to all methods in the *"kernel-specific behavior"* section of `MetaKernel`, plus the magic dispatch infrastructure that calls them
- `Magic.call_magic`, `MagicMagic.get_magic`, and `MetaKernel.get_magic` / `get_magic_args` / `call_magic` / `get_help_on` are now `async def`
- `inspect.isawaitable` guards added in `do_execute`, `do_complete`, `do_shutdown`, and `post_execute` so that `do_execute_meta`, `get_completions`, `restart_kernel`, and `set_variable` can each be overridden as either sync or async
- Built-in magic methods that delegate to overridable hooks (`line_plot`, `line_run`, `cell_debug`, `cell_pipe`, `line_get`, `line_install_magic`, `line_macro`, `cell_macro`, `line_help`, `cell_help`, `get_text_help_on`) updated to `async def`
- IPython compat `@register_line_magic` wrappers updated to `async def` (IPython 7+ supports async magic functions)
- All affected tests updated to wrap now-async public methods with `asyncio.run()`

## Test plan

- [ ] `just test` passes (313 passed, 36 skipped — skips are expected missing-optional-dep skips)
- [ ] No regressions in `test_magic.py`, `test_metakernel.py`, or any magic-specific test module