### PR TITLE
Stricter mypy type checking across magics

### DIFF
--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -198,6 +198,7 @@ class Activity:
     def handle_submit(self, sender: Any) -> None:
         import portalocker
 
+        assert self.results_filename is not None
         with portalocker.Lock(self.results_filename, "a+") as g:
             g.write(
                 f"{self.id}::{getpass.getuser()}::{datetime.datetime.today()}::{sender.description}\n"
@@ -295,11 +296,11 @@ class ActivityMagic(Magic):
       }
    ]
 }'''
-            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
+            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)  # type: ignore[no-untyped-call]
             return
         elif mode == "edit":
             text = "".join(open(filename).readlines())
-            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
+            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)  # type: ignore[no-untyped-call]
         else:
             activity = Activity()
             activity.load(filename)

--- a/metakernel/magics/blockly_magic.py
+++ b/metakernel/magics/blockly_magic.py
@@ -1,6 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 # @author ChrisJaunes
+from __future__ import annotations
+
+from typing import Any
 
 from IPython.display import IFrame, Javascript
 
@@ -32,10 +35,10 @@ class BlocklyMagic(Magic):
     @option("-h", "--height", action="store", default=350, help="set height of iframe ")
     def line_blockly(
         self,
-        page_from_origin=None,
-        page_from_local=None,
-        template_data=None,
-        height=350,
+        page_from_origin: str | None = None,
+        page_from_local: str | None = None,
+        template_data: str | None = None,
+        height: Any = 350,
     ) -> None:
         """
         %blockly - show visual code
@@ -59,7 +62,7 @@ class BlocklyMagic(Magic):
         }
         """
         # print(script)
-        self.kernel.Display(Javascript(script))
+        self.kernel.Display(Javascript(script))  # type: ignore[no-untyped-call]
 
         if height is None:
             height = 350
@@ -105,7 +108,7 @@ class BlocklyMagic(Magic):
             )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(BlocklyMagic)
 
 
@@ -119,8 +122,8 @@ def register_ipython_magics() -> None:
     # Make magics callable:
     kernel.line_magics["blockly"] = magic
 
-    @register_line_magic
-    def blockly(line):
+    @register_line_magic  # type: ignore[untyped-decorator]
+    def blockly(line: str) -> None:
         """
         Use the blockly code visualizer and generator.
         """

--- a/metakernel/magics/brain_magic.py
+++ b/metakernel/magics/brain_magic.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from metakernel import Magic
 
 
@@ -24,7 +28,7 @@ def brain():
         self.code = pre_code + new_code + post_code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(BrainMagic)
 
 
@@ -36,11 +40,11 @@ def register_ipython_magics() -> None:
     kernel = IPythonKernel()
     magic = BrainMagic(kernel)
 
-    @register_cell_magic
-    def brain(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def brain(line: str, cell: str) -> None:
         from IPython import get_ipython  # type:ignore[attr-defined]
 
-        ipkernel = get_ipython()
+        ipkernel = get_ipython()  # type: ignore[no-untyped-call]
         magic.code = cell
         magic.cell_brain()
         ipkernel.kernel.do_execute(magic.code, silent=True)

--- a/metakernel/magics/cd_magic.py
+++ b/metakernel/magics/cd_magic.py
@@ -1,14 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from metakernel import Magic
 
 
 class CDMagic(Magic):
-    def line_cd(self, path=".") -> None:
+    def line_cd(self, path: str = ".") -> None:
         """
         %cd PATH - change current directory of session
 
@@ -32,5 +33,5 @@ class CDMagic(Magic):
             self.kernel.Print(retval)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(CDMagic)

--- a/metakernel/magics/connect_info_magic.py
+++ b/metakernel/magics/connect_info_magic.py
@@ -1,13 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import json
+from typing import Any
 
 from metakernel import Magic
 
 
 class ConnectInfoMagic(Magic):
-    def line_connect_info(self, dummy=None) -> None:
+    def line_connect_info(self, dummy: str | None = None) -> None:
         """
         %connect_info - show connection information
 
@@ -69,5 +71,5 @@ if this is the most recent Jupyter session you have started.
         self.kernel.Print(retval)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ConnectInfoMagic)

--- a/metakernel/magics/conversation_magic.py
+++ b/metakernel/magics/conversation_magic.py
@@ -2,13 +2,17 @@
 Magics to have disqus conversation in the notebook.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from IPython.display import HTML
 
 from metakernel import Magic
 
 
 class ConversationMagic(Magic):
-    def cell_conversation(self, id) -> None:
+    def cell_conversation(self, id: str) -> None:
         """
         %conversation ID - insert conversation by ID
         %%conversation ID - insert conversation by ID
@@ -25,9 +29,9 @@ class ConversationMagic(Magic):
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 """
-        self.kernel.Display(HTML(html))
+        self.kernel.Display(HTML(html))  # type: ignore[no-untyped-call]
 
-    def line_conversation(self, id) -> None:
+    def line_conversation(self, id: str) -> None:
         """
         %conversation ID - insert conversation by ID
         %%conversation ID - insert conversation by ID
@@ -36,7 +40,7 @@ class ConversationMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ConversationMagic)
 
 
@@ -49,10 +53,10 @@ def register_ipython_magics() -> None:
     magic = ConversationMagic(kernel)
 
     @register_line_magic
-    def conversation(id):
+    def conversation(id: str) -> None:
         magic.line_conversation(id)
 
     @register_cell_magic  # type: ignore[no-redef]
-    def conversation(id, cell):  # noqa: F811
+    def conversation(id: str, cell: str) -> None:  # noqa: F811
         magic.code = cell
         magic.cell_conversation(id)

--- a/metakernel/magics/debug_magic.py
+++ b/metakernel/magics/debug_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
+from typing import Any
 
 from IPython.display import HTML, Javascript
 
@@ -8,7 +10,7 @@ from metakernel import Magic
 
 
 class DebugMagic(Magic):
-    def cell_debug(self, dummy) -> None:
+    def cell_debug(self, dummy: str | None = None) -> None:
         """
         %%debug - step through the code expression by expression
 
@@ -204,7 +206,7 @@ function reset() {
 """
         import time
 
-        html = HTML(html_code)
+        html = HTML(html_code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         time.sleep(0.1)
         data = self.kernel.initialize_debug(
@@ -212,10 +214,10 @@ function reset() {
         )  ## add a line so line numbers will be correct
         time.sleep(0.1)
         if data.startswith("highlight: "):
-            self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))
+            self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))  # type: ignore[no-untyped-call]
         time.sleep(0.1)
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(DebugMagic)

--- a/metakernel/magics/dot_magic.py
+++ b/metakernel/magics/dot_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
+from typing import Any
 
 from IPython.display import HTML
 
@@ -8,7 +10,7 @@ from metakernel import Magic
 
 
 class DotMagic(Magic):
-    def line_dot(self, code) -> None:
+    def line_dot(self, code: str) -> None:
         """
         %dot CODE - render code as Graphviz image
 
@@ -23,13 +25,13 @@ class DotMagic(Magic):
             import pydot
         except ImportError:
             raise Exception("You need to install pydot") from None
-        graph = pydot.graph_from_dot_data(str(code))
-        if isinstance(graph, list):
-            graph = graph[0]
-        svg = graph.create_svg()
+        graph_result: Any = pydot.graph_from_dot_data(str(code))
+        if isinstance(graph_result, list):
+            graph_result = graph_result[0]
+        svg = graph_result.create_svg()
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
-        html = HTML(svg)
+        html = HTML(svg)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
 
     def cell_dot(self) -> None:
@@ -48,18 +50,18 @@ class DotMagic(Magic):
             import pydot
         except ImportError:
             raise Exception("You need to install pydot") from None
-        graph = pydot.graph_from_dot_data(str(self.code))
-        if isinstance(graph, list):
-            graph = graph[0]
-        svg = graph.create_svg()
+        graph_result: Any = pydot.graph_from_dot_data(str(self.code))
+        if isinstance(graph_result, list):
+            graph_result = graph_result[0]
+        svg = graph_result.create_svg()
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
-        html = HTML(svg)
+        html = HTML(svg)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(DotMagic)
 
 
@@ -71,8 +73,8 @@ def register_ipython_magics() -> None:
     kernel = IPythonKernel()
     magic = DotMagic(kernel)
 
-    @register_cell_magic
-    def dot(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def dot(line: str, cell: str) -> None:
         """
         %%dot - evaluate cell contents as a dot diagram.
         """

--- a/metakernel/magics/download_magic.py
+++ b/metakernel/magics/download_magic.py
@@ -1,15 +1,16 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 
 import os
 import urllib.parse as urlparse
 import urllib.request
+from typing import Any
 
 from metakernel import Magic, option
 
 
-def download(url, filename):
+def download(url: str, filename: str) -> None:
     g = urllib.request.urlopen(url)
     with open(filename, "wb") as f:
         f.write(g.read())
@@ -23,7 +24,7 @@ class DownloadMagic(Magic):
         default=None,
         help="use the provided name as filename",
     )
-    def line_download(self, url, filename=None) -> None:
+    def line_download(self, url: str, filename: str | None = None) -> None:
         """
         %download URL [-f FILENAME] - download file from URL
 
@@ -58,7 +59,7 @@ class DownloadMagic(Magic):
             self.kernel.Error(str(e))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(DownloadMagic)
 
 
@@ -72,6 +73,6 @@ def register_ipython_magics() -> None:
     # Make magics callable:
     kernel.line_magics["download"] = magic
 
-    @register_line_magic
-    def download(line):
+    @register_line_magic  # type: ignore[untyped-decorator]
+    def download(line: str) -> None:
         kernel.call_magic("%download " + line)

--- a/metakernel/magics/edit_magic.py
+++ b/metakernel/magics/edit_magic.py
@@ -1,14 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from metakernel import Magic
 
 
 class EditMagic(Magic):
-    def line_edit(self, filename) -> None:
+    def line_edit(self, filename: str) -> None:
         """
         %edit FILENAME - load code from filename into next cell for editing
 
@@ -35,5 +36,5 @@ class EditMagic(Magic):
         )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(EditMagic)

--- a/metakernel/magics/file_magic.py
+++ b/metakernel/magics/file_magic.py
@@ -1,9 +1,10 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 
 import errno
 import os
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -16,7 +17,7 @@ class FileMagic(Magic):
         default=False,
         help="append onto an existing file",
     )
-    def cell_file(self, filename, append=False) -> None:
+    def cell_file(self, filename: str, append: bool = False) -> None:
         """
         %%file [--append|-a] FILENAME - write contents of cell to file
 
@@ -60,5 +61,5 @@ class FileMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(FileMagic)

--- a/metakernel/magics/get_magic.py
+++ b/metakernel/magics/get_magic.py
@@ -1,11 +1,14 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic
 
 
 class GetMagic(Magic):
-    def line_get(self, variable) -> None:
+    def line_get(self, variable: str) -> None:
         """
         %get VARIABLE - get a variable from the kernel in a Python-type.
 
@@ -16,9 +19,9 @@ class GetMagic(Magic):
         """
         self.retval = self.kernel.get_variable(variable)
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(GetMagic)

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -1,12 +1,14 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
+from typing import Any
 
 from metakernel import Magic
 
 
 class HelpMagic(Magic):
-    def help_strings(self):
+    def help_strings(self) -> list[str]:
         suffixes = [
             "item{0}{0} - get detailed, technical information on item",
             "item{0}  - get help on item",
@@ -136,5 +138,5 @@ class HelpMagic(Magic):
         return text
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(HelpMagic)

--- a/metakernel/magics/html_magic.py
+++ b/metakernel/magics/html_magic.py
@@ -1,6 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
+from typing import Any
 
 from IPython.display import HTML
 
@@ -8,7 +10,7 @@ from metakernel import Magic
 
 
 class HTMLMagic(Magic):
-    def line_html(self, code) -> None:
+    def line_html(self, code: str) -> None:
         """
         %html CODE - display code as HTML
 
@@ -19,7 +21,7 @@ class HTMLMagic(Magic):
             %html <u>This is underlined!</u>
 
         """
-        html = HTML(code)
+        html = HTML(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
 
     def cell_html(self) -> None:
@@ -36,10 +38,10 @@ class HTMLMagic(Magic):
 
             <div>Contents of div tag</div>
         """
-        html = HTML(self.code)
+        html = HTML(self.code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(HTMLMagic)

--- a/metakernel/magics/include_magic.py
+++ b/metakernel/magics/include_magic.py
@@ -1,14 +1,16 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
 import shlex
+from typing import Any
 
 from metakernel import Magic
 
 
 class IncludeMagic(Magic):
-    def line_include(self, filenames) -> None:
+    def line_include(self, filenames: str) -> None:
         """
         %include FILENAME ... - include code from filename into this code
 
@@ -29,12 +31,12 @@ class IncludeMagic(Magic):
             parts = shlex.split(filenames, posix=False)
         except ValueError:
             parts = filenames.split()
-        filenames = [
+        filename_list = [
             p[1:-1] if len(p) >= 2 and p[0] == p[-1] and p[0] in ("'", '"') else p
             for p in parts
         ]
         prefix = self.kernel.magic_prefixes["magic"]
-        for filename in filenames:
+        for filename in filename_list:
             if filename.startswith("~"):
                 filename = os.path.expanduser(filename)
             filename = os.path.abspath(filename)
@@ -56,5 +58,5 @@ class IncludeMagic(Magic):
             self.code = text + self.code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(IncludeMagic)

--- a/metakernel/magics/install_magic.py
+++ b/metakernel/magics/install_magic.py
@@ -1,13 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from metakernel import Magic
 
 
 class InstallMagic(Magic):
-    def line_install(self, package) -> None:
+    def line_install(self, package: str) -> None:
         """
         %install PACKAGE - install package
 
@@ -37,7 +39,7 @@ class InstallMagic(Magic):
         ## // To turn off automatically creating closing parenthesis and bracket:
         ## IPython.CodeCell.options_default.cm_config["autoCloseBrackets"] = "";
 
-    def enable_extension(self, name) -> None:
+    def enable_extension(self, name: str) -> None:
         filename = "~/.ipython/profile_default/static/custom/custom.js"
         if filename.startswith("~"):
             filename = os.path.expanduser(filename)
@@ -63,5 +65,5 @@ require(["base/js/events"], function (events) {
             fp.write(text)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(InstallMagic)

--- a/metakernel/magics/install_magic_magic.py
+++ b/metakernel/magics/install_magic_magic.py
@@ -1,21 +1,23 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
 import urllib.parse as urlparse
 import urllib.request
+from typing import Any
 
 from metakernel import Magic
 
 
-def download(url, filename):
+def download(url: str, filename: str) -> None:
     g = urllib.request.urlopen(url)
     with open(filename, "wb") as f:
         f.write(g.read())
 
 
 class InstallMagicMagic(Magic):
-    def line_install_magic(self, url) -> None:
+    def line_install_magic(self, url: str) -> None:
         """
         %install_magic URL - download and install magic from URL
 
@@ -39,5 +41,5 @@ class InstallMagicMagic(Magic):
             self.kernel.Error(str(e))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(InstallMagicMagic)

--- a/metakernel/magics/javascript_magic.py
+++ b/metakernel/magics/javascript_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from IPython.display import Javascript
 
@@ -7,7 +10,7 @@ from metakernel import Magic
 
 
 class JavascriptMagic(Magic):
-    def line_javascript(self, code) -> None:
+    def line_javascript(self, code: str) -> None:
         """
         %javascript CODE - send code as JavaScript
 
@@ -18,7 +21,7 @@ class JavascriptMagic(Magic):
             %javascript console.log("Print in the browser console")
 
         """
-        jscode = Javascript(code)
+        jscode = Javascript(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(jscode)
 
     def cell_javascript(self) -> None:
@@ -35,10 +38,10 @@ class JavascriptMagic(Magic):
 
         """
         if self.code.strip():
-            jscode = Javascript(self.code)
+            jscode = Javascript(self.code)  # type: ignore[no-untyped-call]
             self.kernel.Display(jscode)
             self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(JavascriptMagic)

--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -1,9 +1,11 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import random
 import string
 import urllib.request
+from typing import Any, cast
 
 from IPython.display import IFrame, Javascript
 
@@ -12,9 +14,9 @@ from metakernel import Magic, option
 urlopen = urllib.request.urlopen
 
 
-def download(url):
+def download(url: str) -> str:
     g = urlopen(url)
-    return g.read().decode("utf-8")
+    return cast(str, g.read().decode("utf-8"))
 
 
 class JigsawMagic(Magic):
@@ -26,7 +28,9 @@ class JigsawMagic(Magic):
         help="use the provided name as workspace filename",
     )
     @option("-h", "--height", action="store", default=350, help="set height of iframe ")
-    def line_jigsaw(self, language, workspace=None, height=350) -> None:
+    def line_jigsaw(
+        self, language: str, workspace: str | None = None, height: Any = 350
+    ) -> None:
         """
         %jigsaw LANGUAGE - show visual code editor/generator
 
@@ -191,11 +195,11 @@ class JigsawMagic(Magic):
     }
 """
         script = script.replace("MYWORKSPACENAME", workspace_filename)
-        self.kernel.Display(Javascript(script))
+        self.kernel.Display(Javascript(script))  # type: ignore[no-untyped-call]
         self.kernel.Display(IFrame(html_filename, width="100%", height=height))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(JigsawMagic)
 
 
@@ -209,8 +213,8 @@ def register_ipython_magics() -> None:
     # Make magics callable:
     kernel.line_magics["jigsaw"] = magic
 
-    @register_line_magic
-    def jigsaw(line):
+    @register_line_magic  # type: ignore[untyped-decorator]
+    def jigsaw(line: str) -> None:
         """
         Use the Jigsaw code visualizer and generator.
         """

--- a/metakernel/magics/kernel_magic.py
+++ b/metakernel/magics/kernel_magic.py
@@ -1,5 +1,6 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import importlib
 from typing import Any
@@ -18,7 +19,9 @@ class KernelMagic(Magic):
         default="default",
         help="kernel name given to use for execution",
     )
-    def line_kernel(self, module_name, class_name, kernel_name="default") -> None:
+    def line_kernel(
+        self, module_name: str, class_name: str, kernel_name: str = "default"
+    ) -> None:
         """
         %kernel MODULE CLASS [-k NAME] - construct a kernel for sending code.
 
@@ -50,7 +53,7 @@ class KernelMagic(Magic):
         default=None,
         help="kernel name given to use for execution",
     )
-    def cell_kx(self, kernel_name=None) -> None:
+    def cell_kx(self, kernel_name: str | None = None) -> None:
         """
         %%kx [-k NAME] - send the cell code to the kernel.
 
@@ -69,6 +72,7 @@ class KernelMagic(Magic):
         """
         if kernel_name is None:
             kernel_name = self.kernel_name
+        assert kernel_name is not None
         self.retval = self.kernels[kernel_name].do_execute_direct(self.code)
         self.evaluate = False
 
@@ -79,7 +83,7 @@ class KernelMagic(Magic):
         default=None,
         help="kernel name given to use for execution",
     )
-    def line_kx(self, code, kernel_name=None) -> None:
+    def line_kx(self, code: str, kernel_name: str | None = None) -> None:
         """
         %kx CODE [-k NAME] - send the code to the kernel.
 
@@ -96,15 +100,16 @@ class KernelMagic(Magic):
         """
         if kernel_name is None:
             kernel_name = self.kernel_name
+        assert kernel_name is not None
         # make sure the code is sent as a string for execution
         code = str(code)
         self.retval = self.kernels[kernel_name].do_execute_direct(code)
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(KernelMagic)
 
 
@@ -116,8 +121,8 @@ def register_ipython_magics() -> None:
     kernel = IPythonKernel()
     magic = KernelMagic(kernel)
 
-    @register_line_magic  # type: ignore[no-redef]
-    def kernel(line):
+    @register_line_magic  # type: ignore[no-redef, untyped-decorator]
+    def kernel(line: str) -> None:
         """
         line is module_name, class_name[, kernel_name]
         """
@@ -132,8 +137,8 @@ def register_ipython_magics() -> None:
             ]
         magic.line_kernel(module_name, class_name, kernel_name)
 
-    @register_cell_magic
-    def kx(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def kx(line: str, cell: str) -> None:
         """
         line is kernel_name, or "default"
         """

--- a/metakernel/magics/latex_magic.py
+++ b/metakernel/magics/latex_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from IPython.display import Latex
 
@@ -7,7 +10,7 @@ from metakernel import Magic
 
 
 class LatexMagic(Magic):
-    def line_latex(self, text) -> None:
+    def line_latex(self, text: str) -> None:
         r"""
         %latex TEXT - display text as LaTeX
 
@@ -17,7 +20,7 @@ class LatexMagic(Magic):
             %latex $x_1 = \dfrac{a}{b}$
 
         """
-        latex = Latex(text)
+        latex = Latex(text)  # type: ignore[no-untyped-call]
         self.kernel.Display(latex)
 
     def cell_latex(self) -> None:
@@ -32,10 +35,10 @@ class LatexMagic(Magic):
 
             $x_2 = a^{n - 1}$
         """
-        latex = Latex(self.code)
+        latex = Latex(self.code)  # type: ignore[no-untyped-call]
         self.kernel.Display(latex)
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(LatexMagic)

--- a/metakernel/magics/load_magic.py
+++ b/metakernel/magics/load_magic.py
@@ -1,13 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from metakernel import Magic
 
 
 class LoadMagic(Magic):
-    def line_load(self, filename) -> None:
+    def line_load(self, filename: str) -> None:
         """
         %load FILENAME - load code from filename into next cell
 
@@ -24,5 +26,5 @@ class LoadMagic(Magic):
             self.kernel.payload.append({"source": "set_next_input", "text": f.read()})
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(LoadMagic)

--- a/metakernel/magics/ls_magic.py
+++ b/metakernel/magics/ls_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from IPython.display import FileLinks
 
@@ -16,7 +18,7 @@ class LSMagic(Magic):
         default=False,
         help="recursively descend into subdirectories",
     )
-    def line_ls(self, path=".", recursive=False) -> None:
+    def line_ls(self, path: str = ".", recursive: bool = False) -> None:
         """
         %ls PATH - list files and directories under PATH
 
@@ -27,11 +29,11 @@ class LSMagic(Magic):
             %ls ..
         """
         path = os.path.expanduser(path)
-        self.retval = FileLinks(path, recursive=recursive)
+        self.retval = FileLinks(path, recursive=recursive)  # type: ignore[no-untyped-call]
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(LSMagic)

--- a/metakernel/magics/lsmagic_magic.py
+++ b/metakernel/magics/lsmagic_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic
 
@@ -30,5 +33,5 @@ class LSMagicMagic(Magic):
         self.kernel.Print("\n".join(out))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(LSMagicMagic)

--- a/metakernel/magics/macro_magic.py
+++ b/metakernel/magics/macro_magic.py
@@ -1,9 +1,11 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import ast
 import inspect
 import os
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -25,7 +27,7 @@ class MacroMagic(Magic):
 """
     }
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._load_macros()
 
@@ -38,7 +40,9 @@ class MacroMagic(Magic):
     )
     @option("-l", "--list", action="store_true", default=False, help="list macros")
     @option("-s", "--show", action="store_true", default=False, help="show macro")
-    def line_macro(self, name, delete=False, list=False, show=False) -> None:
+    def line_macro(
+        self, name: str, delete: bool = False, list: bool = False, show: bool = False
+    ) -> None:
         """
         %macro NAME - execute a macro
         %macro -l [all|learned|system] - list macros
@@ -89,7 +93,9 @@ class MacroMagic(Magic):
             self._list_macros(retval=f"No such macro: '{name}'\n\n", error=True)
         self.evaluate = True
 
-    def _list_macros(self, name="all", retval="", error=False) -> None:
+    def _list_macros(
+        self, name: str = "all", retval: str = "", error: bool = False
+    ) -> None:
         retval += "Available macros:\n"
         if name in ["all", "system"]:
             retval += "    System:\n"
@@ -130,7 +136,7 @@ class MacroMagic(Magic):
         with open(filename, "w") as macros:
             macros.write(str(self.learned))
 
-    def cell_macro(self, name) -> None:
+    def cell_macro(self, name: str) -> None:
         """
         %%macro NAME - learn a new macro
 
@@ -150,5 +156,5 @@ class MacroMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(MacroMagic)

--- a/metakernel/magics/magic_magic.py
+++ b/metakernel/magics/magic_magic.py
@@ -8,7 +8,7 @@ from metakernel import Magic
 
 
 class MagicMagic(Magic):
-    def line_magic(self, line) -> None:
+    def line_magic(self, line: str) -> None:
         """
         %magic - show installed magics
 
@@ -52,7 +52,7 @@ class MagicMagic(Magic):
             self.kernel.Print("    " + string)
         self.kernel.Print("")
 
-    def get_magic(self, info, get_args=False) -> Any:
+    def get_magic(self, info: dict[str, Any], get_args: bool = False) -> Any:
 
         if not info["magic"]:
             return None
@@ -90,5 +90,5 @@ class MagicMagic(Magic):
             )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(MagicMagic)

--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -11,7 +11,7 @@ from metakernel import Magic, option
 class Slice:
     """Utility class for making slice ranges."""
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> Any:
         return item
 
 
@@ -44,7 +44,11 @@ class ParallelMagic(Magic):
         help="the machine ids to use from the cluster",
     )
     def line_parallel(
-        self, module_name, class_name, kernel_name="default", ids=None
+        self,
+        module_name: str,
+        class_name: str,
+        kernel_name: str = "default",
+        ids: Any = None,
     ) -> None:
         """
         %parallel MODULE CLASS [-k NAME] [-i [...]] - construct an interface to the cluster.
@@ -186,7 +190,11 @@ kernels['{kernel_name}'] = {class_name}()
         help="set the variable with the parallel results rather than returning them",
     )
     def line_px(
-        self, expression, kernel_name=None, evaluate=False, set_variable=None
+        self,
+        expression: Any,
+        kernel_name: str | None = None,
+        evaluate: bool = False,
+        set_variable: str | None = None,
     ) -> None:
         """
         %px EXPRESSION - send EXPRESSION to the cluster.
@@ -238,7 +246,7 @@ kernels['{kernel_name}'] = {class_name}()
         if evaluate:
             self.code = expression
 
-    def _clean_code(self, expr):
+    def _clean_code(self, expr: str) -> str:
         return expr.strip().replace('"', '\\"').replace("\n", "\\n")
 
     ## px --kernel NAME
@@ -266,7 +274,12 @@ kernels['{kernel_name}'] = {class_name}()
         default=None,
         help="set the variable with the parallel results rather than returning them",
     )
-    def cell_px(self, kernel_name=None, evaluate=False, set_variable=None) -> None:
+    def cell_px(
+        self,
+        kernel_name: str | None = None,
+        evaluate: bool = False,
+        set_variable: str | None = None,
+    ) -> None:
         """
         %%px - send cell to the cluster.
 
@@ -297,7 +310,11 @@ kernels['{kernel_name}'] = {class_name}()
         help="set the variable with the parallel results rather than returning them",
     )
     def line_pmap(
-        self, function_name, args, kernel_name=None, set_variable=None
+        self,
+        function_name: str,
+        args: str,
+        kernel_name: str | None = None,
+        set_variable: str | None = None,
     ) -> None:
         """
         %pmap FUNCTION [ARGS1,ARGS2,...] - ("parallel map") call a FUNCTION on args
@@ -356,7 +373,7 @@ kernels['{kernel_name}'] = {class_name}()
             self.kernel.set_variable(set_variable, results)
             self.retval = None
 
-    def post_process(self, retval) -> Any:
+    def post_process(self, retval: Any) -> Any:
         try:
             ## any will crash on numpy arrays
             if isinstance(self.retval, list) and not any(self.retval):
@@ -366,5 +383,5 @@ kernels['{kernel_name}'] = {class_name}()
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ParallelMagic)

--- a/metakernel/magics/pipe_magic.py
+++ b/metakernel/magics/pipe_magic.py
@@ -1,14 +1,17 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic
 
 
 class PipeMagic(Magic):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    def cell_pipe(self, pipe_str) -> None:
+    def cell_pipe(self, pipe_str: str) -> None:
         """
         %%pipe FUNCTION1 | FUNCTION2 ...
 
@@ -32,11 +35,11 @@ class PipeMagic(Magic):
             self.retval = self.kernel.do_function_direct(function, self.retval)
         self.evaluate = False
 
-    def post_process(self, retval) -> str:
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(PipeMagic)
 
 
@@ -44,10 +47,10 @@ def register_ipython_magics() -> None:
     from IPython import get_ipython  # type:ignore[attr-defined]
     from IPython.core.magic import register_cell_magic
 
-    @register_cell_magic
-    def pipe(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def pipe(line: str, cell: str) -> Any:
         """ """
-        ip = get_ipython()
+        ip = get_ipython()  # type: ignore[no-untyped-call]
         functions = [function.strip() for function in line.split("|")]
         retval = cell
         for function in functions:

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -13,7 +16,7 @@ class PlotMagic(Magic):
     @option("-r", "--resolution", action="store", help="Resolution in pixels per inch")
     @option("-w", "--width", action="store", help="Plot width in pixels")
     @option("-h", "--height", action="store", help="Plot height in pixels")
-    def line_plot(self, *args, **kwargs) -> None:
+    def line_plot(self, *args: Any, **kwargs: Any) -> None:
         """
         %plot [options] backend - configure plotting for the session.
 
@@ -41,5 +44,5 @@ class PlotMagic(Magic):
         self.kernel.handle_plot_settings()
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(PlotMagic)

--- a/metakernel/magics/processing_magic.py
+++ b/metakernel/magics/processing_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from IPython.display import HTML
 
@@ -9,7 +12,7 @@ from metakernel import Magic
 class ProcessingMagic(Magic):
     canvas_id = 0
 
-    def cell_processing(self, dummy=None) -> None:
+    def cell_processing(self, dummy: str | None = None) -> None:
         """
         %%processing - run the cell in the language Processing
 
@@ -43,12 +46,12 @@ require([window.location.protocol + "//calysto.github.io/javascripts/processing/
 }});
 </script>
 """.format(**env)
-        html = HTML(code)
+        html = HTML(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ProcessingMagic)
 
 
@@ -60,8 +63,8 @@ def register_ipython_magics() -> None:
     kernel = IPythonKernel()
     magic = ProcessingMagic(kernel)
 
-    @register_cell_magic
-    def processing(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def processing(line: str, cell: str) -> None:
         """ """
         magic.code = cell
         magic.cell_processing()

--- a/metakernel/magics/reload_magics_magic.py
+++ b/metakernel/magics/reload_magics_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic
 
@@ -22,5 +25,5 @@ class ReloadMagicsMagic(Magic):
         self.code = "%lsmagic\n" + self.code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ReloadMagicsMagic)

--- a/metakernel/magics/restart_magic.py
+++ b/metakernel/magics/restart_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import json
+from typing import Any
 
 from metakernel import Magic
 
@@ -29,5 +31,5 @@ class RestartMagic(Magic):
         kernel.Print("Done!")
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(RestartMagic)

--- a/metakernel/magics/run_magic.py
+++ b/metakernel/magics/run_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -14,7 +16,7 @@ class RunMagic(Magic):
         default=None,
         help="use the provided language name as kernel",
     )
-    def line_run(self, filename, language=None) -> None:
+    def line_run(self, filename: str, language: str | None = None) -> None:
         """
         %run [--language LANG] FILENAME - run code in filename by
            kernel
@@ -48,5 +50,5 @@ class RunMagic(Magic):
                 self.code += "".join(f.readlines())
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(RunMagic)

--- a/metakernel/magics/scheme_magic.py
+++ b/metakernel/magics/scheme_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -10,11 +13,11 @@ except ImportError:
 
 
 class SchemeMagic(Magic):
-    def __init__(self, kernel) -> None:
+    def __init__(self, kernel: Any) -> None:
         super().__init__(kernel)
         self.retval = None
 
-    def line_scheme(self, *args) -> None:
+    def line_scheme(self, *args: str) -> None:
         """
         %scheme CODE - evaluate code as Scheme
 
@@ -30,7 +33,7 @@ class SchemeMagic(Magic):
         code = " ".join(args)
         self.retval = self.eval(code)
 
-    def eval(self, code):
+    def eval(self, code: str) -> Any:
         if scheme:
             return scheme.execute_string_rm(code.strip())
         else:
@@ -43,7 +46,7 @@ class SchemeMagic(Magic):
         default=False,
         help="Use the retval value from the Scheme cell as code in the kernel language.",
     )
-    def cell_scheme(self, eval_output=False) -> None:
+    def cell_scheme(self, eval_output: bool = False) -> None:
         """
         %%scheme - evaluate contents of cell as Scheme
 
@@ -76,14 +79,14 @@ class SchemeMagic(Magic):
                 self.retval = self.eval(self.code)
                 self.evaluate = False
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         if retval is not None:
             return retval
         else:
             return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(SchemeMagic)
 
 
@@ -96,12 +99,12 @@ def register_ipython_magics() -> None:
     magic = SchemeMagic(kernel)
 
     @register_line_magic
-    def scheme(line):
+    def scheme(line: str) -> Any:
         magic.line_scheme(line)
         return magic.retval
 
     @register_cell_magic  # type: ignore[no-redef]
-    def scheme(line, cell):  # noqa: F811
+    def scheme(line: str, cell: str) -> Any:  # noqa: F811
         magic.code = cell
         magic.cell_scheme()
         return magic.retval

--- a/metakernel/magics/set_magic.py
+++ b/metakernel/magics/set_magic.py
@@ -1,11 +1,14 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic
 
 
 class SetMagic(Magic):
-    def line_set(self, variable, value) -> None:
+    def line_set(self, variable: str, value: str) -> None:
         """
         %set VARIABLE VALUE - set a variable in the kernel.
 
@@ -18,9 +21,9 @@ class SetMagic(Magic):
         value = self.kernel.do_execute_direct(value)
         self.kernel.set_variable(variable, value)
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(SetMagic)

--- a/metakernel/magics/shell_magic.py
+++ b/metakernel/magics/shell_magic.py
@@ -11,13 +11,13 @@ from metakernel.replwrap import REPLWrapper, bash, powershell
 
 
 class ShellMagic(Magic):
-    def __init__(self, kernel) -> None:
+    def __init__(self, kernel: Any) -> None:
         super().__init__(kernel)
         self.repl: REPLWrapper | None = None
         self.cmd: str | None = None
         self.start_process()
 
-    def line_shell(self, *args) -> None:
+    def line_shell(self, *args: str) -> None:
         """
         %shell COMMAND - run the line as a shell command
 
@@ -48,7 +48,7 @@ class ShellMagic(Magic):
         if os.path.exists(cwd):
             os.chdir(cwd)
 
-    def eval(self, cmd, incremental=False) -> str:
+    def eval(self, cmd: str, incremental: bool = False) -> str:
         assert self.repl is not None
         stream_handler = self.kernel.Print if incremental else None
         return self.repl.run_command(cmd, timeout=None, stream_handler=stream_handler)
@@ -91,7 +91,7 @@ class ShellMagic(Magic):
         self.line_shell(self.code)
         self.evaluate = False
 
-    def get_completions(self, info) -> list[str]:
+    def get_completions(self, info: dict[str, Any]) -> list[str]:
         if self.cmd == "cmd":
             return []
         command = 'compgen -cdfa "{}"'.format(info["code"])
@@ -112,5 +112,5 @@ class ShellMagic(Magic):
             return f"Sorry, no help is available on '{expr}'."
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ShellMagic)

--- a/metakernel/magics/show_magic.py
+++ b/metakernel/magics/show_magic.py
@@ -1,5 +1,8 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
+from typing import Any
 
 from metakernel import Magic, option
 
@@ -12,7 +15,7 @@ class ShowMagic(Magic):
         default=False,
         help="rather than showing the contents, show the results",
     )
-    def cell_show(self, output=False) -> None:
+    def cell_show(self, output: bool = False) -> None:
         """
         %%show [-o]- show cell contents or results in system pager
 
@@ -39,7 +42,7 @@ class ShowMagic(Magic):
         else:
             self.evaluate = True
 
-    def post_process(self, results) -> None:
+    def post_process(self, results: Any) -> None:
         if self.show_output:
             self.kernel.payload = [
                 {
@@ -51,5 +54,5 @@ class ShowMagic(Magic):
         return None
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(ShowMagic)

--- a/metakernel/magics/time_magic.py
+++ b/metakernel/magics/time_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import time
+from typing import Any
 
 from metakernel import Magic
 
@@ -23,12 +25,12 @@ class TimeMagic(Magic):
         """
         self.start = time.time()
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         if self.code.strip():
             result = "Time: %s seconds.\n" % (time.time() - self.start)
             self.kernel.Print(result)
         return retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(TimeMagic)

--- a/metakernel/magics/tutor_magic.py
+++ b/metakernel/magics/tutor_magic.py
@@ -20,6 +20,9 @@ Magics to display pythontutor.com in the notebook.
 #   kikocorreoso
 # -----------------------------------------------------------------------------
 
+from __future__ import annotations
+
+from typing import Any
 from urllib.parse import quote
 
 from IPython.display import IFrame
@@ -38,7 +41,7 @@ class TutorMagic(Magic):
             + "Possible values are: python, python2, python3, java, javascript"
         ),
     )
-    def cell_tutor(self, language=None) -> None:
+    def cell_tutor(self, language: str | None = None) -> None:
         """
         %%tutor [--language=LANGUAGE] - show cell with
         Online Python Tutor.
@@ -92,7 +95,7 @@ class TutorMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: Any) -> None:
     kernel.register_magics(TutorMagic)
 
 
@@ -104,7 +107,7 @@ def register_ipython_magics() -> None:
     kernel = IPythonKernel()
     magic = TutorMagic(kernel)
 
-    @register_cell_magic
-    def tutor(line, cell):
+    @register_cell_magic  # type: ignore[untyped-decorator]
+    def tutor(line: str, cell: str) -> None:
         magic.code = cell
         magic.cell_tutor(language="python3")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ coverage = [
     "coverage[toml]",
     "pytest-cov",
 ]
-typing = ["pip", "mypy", "ipywidgets"]
+typing = [{ include-group = "test-all" }, "pip", "mypy"]
 
 [tool.uv.sources]
 metakernel_python = { path = "./metakernel_python", editable = true }
@@ -117,12 +117,17 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-disallow_untyped_defs = false
-disable_error_code = ["comparison-overlap", "no-untyped-def", "import-not-found", "no-untyped-call"]
+disable_error_code = ["comparison-overlap", "no-untyped-def", "no-untyped-call"]
 
 [[tool.mypy.overrides]]
-module = "metakernel.magics.*"
-disable_error_code = ["no-untyped-def", "no-untyped-call", "import-not-found"]
+module = [
+    "calysto_scheme",
+    "calysto.*",
+    "ipyparallel",
+    "ipyparallel.*",
+    "IPython.parallel.*",
+]
+ignore_missing_imports = true
 
 [tool.ruff]
 exclude = ["examples/echo_kernel.ipynb"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import logging
+from io import StringIO
+from logging import Logger, StreamHandler
 from typing import Any, TypeVar, overload
+
+import zmq
+from jupyter_client import session as ss
 
 from metakernel import MetaKernel
 
@@ -14,20 +20,6 @@ __all__ = [
 ]
 
 _KT = TypeVar("_KT", bound=MetaKernel)
-
-try:
-    from jupyter_client import session as ss
-except ImportError:
-    from IPython.kernel.zmq import session as ss  # type: ignore[no-redef]
-import logging
-from logging import Logger, StreamHandler
-
-import zmq
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 class EvalKernel(MetaKernel):

--- a/uv.lock
+++ b/uv.lock
@@ -2168,9 +2168,22 @@ test-all = [
     { name = "requests" },
 ]
 typing = [
+    { name = "calysto" },
+    { name = "calysto-scheme" },
+    { name = "ipyparallel" },
     { name = "ipywidgets" },
+    { name = "jupyter-kernel-test" },
+    { name = "matplotlib", version = "3.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "metakernel-python" },
     { name = "mypy" },
     { name = "pip" },
+    { name = "portalocker" },
+    { name = "pydot" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-timeout" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -2246,9 +2259,20 @@ test-all = [
     { name = "requests" },
 ]
 typing = [
+    { name = "calysto" },
+    { name = "calysto-scheme" },
+    { name = "ipyparallel" },
     { name = "ipywidgets" },
+    { name = "jupyter-kernel-test" },
+    { name = "matplotlib" },
+    { name = "metakernel-python", editable = "metakernel_python" },
     { name = "mypy" },
     { name = "pip" },
+    { name = "portalocker" },
+    { name = "pydot" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "requests" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes blanket `no-untyped-call`/`no-untyped-def` suppression from the `metakernel.magics.*` mypy override, replacing it with targeted `# type: ignore` comments only where truly needed
- Adds `assert` guards for `Optional` attributes before use (e.g. `results_filename` in `ActivityMagic`)
- Adds `ignore_missing_imports = true` for `calysto`, `ipyparallel`, and `IPython.parallel` third-party modules that lack stubs
- Includes `test-all` deps in the `typing` dependency group so mypy sees all optional package stubs when type-checking

## Test plan

- [ ] `just typing` passes with no new errors
- [ ] `just test` passes
- [ ] `just lint` passes