### PR TITLE
Add typed get_ipython() helper and resolve all mypy errors in magics

### DIFF
--- a/metakernel/__init__.py
+++ b/metakernel/__init__.py
@@ -11,7 +11,7 @@ from ._metakernel import (
     get_metakernel,
     register_ipython_magics,
 )
-from .magic import Magic, option
+from .magic import Magic, get_ipython, option
 from .parser import Parser
 from .process_metakernel import ProcessMetaKernel
 from .replwrap import REPLWrapper
@@ -31,6 +31,7 @@ __all__ = [
     "Parser",
     "ProcessMetaKernel",
     "REPLWrapper",
+    "get_ipython",
     "get_metakernel",
     "option",
     "pexpect",

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -26,6 +26,7 @@ from traitlets import Dict, Unicode
 from traitlets.config import Application
 
 from .config import get_history_file, get_local_magics_dir
+from .magic import get_ipython
 from .parser import Parser
 
 if TYPE_CHECKING:
@@ -190,12 +191,11 @@ class MetaKernel(Kernel):
         Run this method in an IPython kernel to set
         this kernel's input/output settings.
         """
-        from IPython import get_ipython  # type:ignore[attr-defined]
         from IPython.display import display
 
-        shell = get_ipython()  # type:ignore[no-untyped-call]
+        shell = get_ipython()
         if shell:  # we are running under an IPython kernel
-            self.session = shell.kernel.session
+            self.session = shell.kernel.session  # type: ignore[attr-defined]
             self.Display = display  # type: ignore[method-assign]
             self.send_response = self._send_shell_response  # type: ignore[method-assign]
         else:

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -7,9 +7,11 @@ import shlex
 import sys
 import traceback
 from ast import literal_eval as safe_eval
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar, cast
 
 if TYPE_CHECKING:
+    from IPython.core.interactiveshell import InteractiveShell
+
     from . import MetaKernel
 
 _F = TypeVar("_F", bound=Callable[..., Any])
@@ -145,6 +147,13 @@ class Magic:
 
     def post_process(self, retval: Any) -> Any:
         return retval
+
+
+def get_ipython() -> InteractiveShell | None:
+    """Return the running IPython shell instance, or None if not in IPython."""
+    from IPython import get_ipython as _get_ipython  # type: ignore[attr-defined]
+
+    return cast("InteractiveShell | None", _get_ipython())  # type: ignore[no-untyped-call]
 
 
 def option(*args: Any, **kwargs: Any) -> Callable[[_F], _F]:

--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     widgets = None
 
-from metakernel import Magic, MetaKernel
+from metakernel import Magic, MetaKernel, get_ipython
 
 
 def touch(fname: str, times: Any = None) -> None:
@@ -183,7 +183,7 @@ class Activity:
         barvalues = [int(value) for key, value in sorted(choices.items())]
         self.stack.layout.width = "55%"
         try:
-            from calysto.graphics import BarChart
+            from calysto.graphics import BarChart  # type: ignore[import-untyped]
 
             barchart = BarChart(
                 size=(300, 400), data=barvalues, labels=sorted(choices.keys())
@@ -198,6 +198,7 @@ class Activity:
     def handle_submit(self, sender: Any) -> None:
         import portalocker
 
+        assert self.results_filename is not None
         with portalocker.Lock(self.results_filename, "a+") as g:
             g.write(
                 f"{self.id}::{getpass.getuser()}::{datetime.datetime.today()}::{sender.description}\n"
@@ -246,8 +247,6 @@ class ActivityMagic(Magic):
             %activity /home/teacher/activity1 new
             %activity /home/teacher/activity1 edit
         """
-        from IPython import get_ipython  # type:ignore[attr-defined]
-
         if mode == "new":
             text = '''
 {"activity": "poll",
@@ -295,11 +294,15 @@ class ActivityMagic(Magic):
       }
    ]
 }'''
-            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
+            ip = get_ipython()
+            if ip is not None:
+                ip.set_next_input((f"%%activity {filename}\n\n") + text)
             return
         elif mode == "edit":
             text = "".join(open(filename).readlines())
-            get_ipython().set_next_input((f"%%activity {filename}\n\n") + text)
+            ip = get_ipython()
+            if ip is not None:
+                ip.set_next_input((f"%%activity {filename}\n\n") + text)
         else:
             activity = Activity()
             activity.load(filename)

--- a/metakernel/magics/blockly_magic.py
+++ b/metakernel/magics/blockly_magic.py
@@ -59,7 +59,7 @@ class BlocklyMagic(Magic):
         }
         """
         # print(script)
-        self.kernel.Display(Javascript(script))
+        self.kernel.Display(Javascript(script))  # type: ignore[no-untyped-call]
 
         if height is None:
             height = 350

--- a/metakernel/magics/brain_magic.py
+++ b/metakernel/magics/brain_magic.py
@@ -1,4 +1,4 @@
-from metakernel import Magic
+from metakernel import Magic, get_ipython
 
 
 class BrainMagic(Magic):
@@ -38,9 +38,9 @@ def register_ipython_magics() -> None:
 
     @register_cell_magic
     def brain(line, cell):
-        from IPython import get_ipython  # type:ignore[attr-defined]
-
         ipkernel = get_ipython()
+        if ipkernel is None:
+            return
         magic.code = cell
         magic.cell_brain()
-        ipkernel.kernel.do_execute(magic.code, silent=True)
+        ipkernel.kernel.do_execute(magic.code, silent=True)  # type: ignore[attr-defined]

--- a/metakernel/magics/conversation_magic.py
+++ b/metakernel/magics/conversation_magic.py
@@ -25,7 +25,7 @@ class ConversationMagic(Magic):
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 """
-        self.kernel.Display(HTML(html))
+        self.kernel.Display(HTML(html))  # type: ignore[no-untyped-call]
 
     def line_conversation(self, id) -> None:
         """

--- a/metakernel/magics/debug_magic.py
+++ b/metakernel/magics/debug_magic.py
@@ -204,7 +204,7 @@ function reset() {
 """
         import time
 
-        html = HTML(html_code)
+        html = HTML(html_code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         time.sleep(0.1)
         data = self.kernel.initialize_debug(
@@ -212,7 +212,7 @@ function reset() {
         )  ## add a line so line numbers will be correct
         time.sleep(0.1)
         if data.startswith("highlight: "):
-            self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))
+            self.kernel.Display(Javascript(f"highlight(cell, {data[11:]});"))  # type: ignore[no-untyped-call]
         time.sleep(0.1)
         self.evaluate = False
 

--- a/metakernel/magics/dot_magic.py
+++ b/metakernel/magics/dot_magic.py
@@ -26,7 +26,7 @@ class DotMagic(Magic):
         graph = pydot.graph_from_dot_data(str(code))
         if not graph:
             return
-        svg = graph[0].create_svg()  # type: ignore[attr-defined]
+        svg = graph[0].create_svg()  # type: ignore[attr-defined, unused-ignore]
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
         html = HTML(svg)  # type: ignore[no-untyped-call]
@@ -51,7 +51,7 @@ class DotMagic(Magic):
         graph = pydot.graph_from_dot_data(str(self.code))
         if not graph:
             return
-        svg = graph[0].create_svg()  # type: ignore[attr-defined]
+        svg = graph[0].create_svg()  # type: ignore[attr-defined, unused-ignore]
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
         html = HTML(svg)  # type: ignore[no-untyped-call]

--- a/metakernel/magics/dot_magic.py
+++ b/metakernel/magics/dot_magic.py
@@ -24,12 +24,12 @@ class DotMagic(Magic):
         except ImportError:
             raise Exception("You need to install pydot") from None
         graph = pydot.graph_from_dot_data(str(code))
-        if isinstance(graph, list):
-            graph = graph[0]
-        svg = graph.create_svg()
+        if not graph:
+            return
+        svg = graph[0].create_svg()  # type: ignore[attr-defined]
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
-        html = HTML(svg)
+        html = HTML(svg)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
 
     def cell_dot(self) -> None:
@@ -49,12 +49,12 @@ class DotMagic(Magic):
         except ImportError:
             raise Exception("You need to install pydot") from None
         graph = pydot.graph_from_dot_data(str(self.code))
-        if isinstance(graph, list):
-            graph = graph[0]
-        svg = graph.create_svg()
+        if not graph:
+            return
+        svg = graph[0].create_svg()  # type: ignore[attr-defined]
         if hasattr(svg, "decode"):
             svg = svg.decode("utf-8")
-        html = HTML(svg)
+        html = HTML(svg)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 

--- a/metakernel/magics/download_magic.py
+++ b/metakernel/magics/download_magic.py
@@ -52,7 +52,7 @@ class DownloadMagic(Magic):
         filename = filename.replace("~", "")
         filename = filename.replace("%20", "_")
         try:
-            download(url, filename)
+            download(url, filename)  # type: ignore[no-untyped-call]
             self.kernel.Print(f"Downloaded '{filename}'.")
         except Exception as e:
             self.kernel.Error(str(e))

--- a/metakernel/magics/html_magic.py
+++ b/metakernel/magics/html_magic.py
@@ -19,7 +19,7 @@ class HTMLMagic(Magic):
             %html <u>This is underlined!</u>
 
         """
-        html = HTML(code)
+        html = HTML(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
 
     def cell_html(self) -> None:
@@ -36,7 +36,7 @@ class HTMLMagic(Magic):
 
             <div>Contents of div tag</div>
         """
-        html = HTML(self.code)
+        html = HTML(self.code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 

--- a/metakernel/magics/install_magic_magic.py
+++ b/metakernel/magics/install_magic_magic.py
@@ -32,7 +32,7 @@ class InstallMagicMagic(Magic):
         filename = os.path.basename(path)
         magic_filename = os.path.join(self.kernel.get_local_magics_dir(), filename)
         try:
-            download(url, magic_filename)
+            download(url, magic_filename)  # type: ignore[no-untyped-call]
             self.kernel.Print(f"Downloaded '{magic_filename}'.")
             self.code = "%reload_magics\n" + self.code
         except Exception as e:

--- a/metakernel/magics/javascript_magic.py
+++ b/metakernel/magics/javascript_magic.py
@@ -18,7 +18,7 @@ class JavascriptMagic(Magic):
             %javascript console.log("Print in the browser console")
 
         """
-        jscode = Javascript(code)
+        jscode = Javascript(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(jscode)
 
     def cell_javascript(self) -> None:
@@ -35,7 +35,7 @@ class JavascriptMagic(Magic):
 
         """
         if self.code.strip():
-            jscode = Javascript(self.code)
+            jscode = Javascript(self.code)  # type: ignore[no-untyped-call]
             self.kernel.Display(jscode)
             self.evaluate = False
 

--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -47,7 +47,7 @@ class JigsawMagic(Magic):
                 )
             )
         workspace_filename = workspace + ".xml"
-        html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")
+        html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")  # type: ignore[no-untyped-call]
         html_filename = workspace + ".html"
         html_text = html_text.replace("MYWORKSPACENAME", workspace_filename)
         with open(html_filename, "w") as fp:
@@ -191,7 +191,7 @@ class JigsawMagic(Magic):
     }
 """
         script = script.replace("MYWORKSPACENAME", workspace_filename)
-        self.kernel.Display(Javascript(script))
+        self.kernel.Display(Javascript(script))  # type: ignore[no-untyped-call]
         self.kernel.Display(IFrame(html_filename, width="100%", height=height))
 
 

--- a/metakernel/magics/latex_magic.py
+++ b/metakernel/magics/latex_magic.py
@@ -17,7 +17,7 @@ class LatexMagic(Magic):
             %latex $x_1 = \dfrac{a}{b}$
 
         """
-        latex = Latex(text)
+        latex = Latex(text)  # type: ignore[no-untyped-call]
         self.kernel.Display(latex)
 
     def cell_latex(self) -> None:
@@ -32,7 +32,7 @@ class LatexMagic(Magic):
 
             $x_2 = a^{n - 1}$
         """
-        latex = Latex(self.code)
+        latex = Latex(self.code)  # type: ignore[no-untyped-call]
         self.kernel.Display(latex)
         self.evaluate = False
 

--- a/metakernel/magics/ls_magic.py
+++ b/metakernel/magics/ls_magic.py
@@ -27,7 +27,7 @@ class LSMagic(Magic):
             %ls ..
         """
         path = os.path.expanduser(path)
-        self.retval = FileLinks(path, recursive=recursive)
+        self.retval = FileLinks(path, recursive=recursive)  # type: ignore[no-untyped-call]
 
     def post_process(self, retval):
         return self.retval

--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -343,8 +343,8 @@ kernels['{kernel_name}'] = {class_name}()
         try:
             from ipyparallel.util import interactive  # type: ignore[import-untyped]
         except ImportError:
-            from IPython.parallel.util import (
-                interactive,  # type: ignore[import-not-found]
+            from IPython.parallel.util import (  # type: ignore[import-not-found]
+                interactive,
             )
         f = interactive(
             lambda arg, kname=kernel_name, fname=function_name: kernels[  # type:ignore[name-defined]  # noqa: F821

--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -61,7 +61,7 @@ class ParallelMagic(Magic):
 
         Use %px or %%px to send code to the cluster.
         """
-        from ipyparallel import Client
+        from ipyparallel import Client  # type: ignore[import-untyped]
 
         count = 1
         while count <= 5:
@@ -238,7 +238,7 @@ kernels['{kernel_name}'] = {class_name}()
         if evaluate:
             self.code = expression
 
-    def _clean_code(self, expr):
+    def _clean_code(self, expr: str) -> str:
         return expr.strip().replace('"', '\\"').replace("\n", "\\n")
 
     ## px --kernel NAME
@@ -341,9 +341,11 @@ kernels['{kernel_name}'] = {class_name}()
 
         # To make sure we can find `kernels`:
         try:
-            from ipyparallel.util import interactive
+            from ipyparallel.util import interactive  # type: ignore[import-untyped]
         except ImportError:
-            from IPython.parallel.util import interactive
+            from IPython.parallel.util import (
+                interactive,  # type: ignore[import-not-found]
+            )
         f = interactive(
             lambda arg, kname=kernel_name, fname=function_name: kernels[  # type:ignore[name-defined]  # noqa: F821
                 kname

--- a/metakernel/magics/pipe_magic.py
+++ b/metakernel/magics/pipe_magic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic
+from metakernel import Magic, get_ipython
 
 
 class PipeMagic(Magic):
@@ -41,13 +41,14 @@ def register_magics(kernel) -> None:
 
 
 def register_ipython_magics() -> None:
-    from IPython import get_ipython  # type:ignore[attr-defined]
     from IPython.core.magic import register_cell_magic
 
     @register_cell_magic
     def pipe(line, cell):
         """ """
         ip = get_ipython()
+        if ip is None:
+            return
         functions = [function.strip() for function in line.split("|")]
         retval = cell
         for function in functions:

--- a/metakernel/magics/processing_magic.py
+++ b/metakernel/magics/processing_magic.py
@@ -43,7 +43,7 @@ require([window.location.protocol + "//calysto.github.io/javascripts/processing/
 }});
 </script>
 """.format(**env)
-        html = HTML(code)
+        html = HTML(code)  # type: ignore[no-untyped-call]
         self.kernel.Display(html)
         self.evaluate = False
 

--- a/metakernel/magics/scheme_magic.py
+++ b/metakernel/magics/scheme_magic.py
@@ -1,10 +1,12 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from typing import Any
+
 from metakernel import Magic, option
 
 try:
-    from calysto_scheme import scheme
+    from calysto_scheme import scheme  # type: ignore[import-untyped]
 except ImportError:
     scheme = None
 
@@ -30,7 +32,7 @@ class SchemeMagic(Magic):
         code = " ".join(args)
         self.retval = self.eval(code)
 
-    def eval(self, code):
+    def eval(self, code: str) -> Any:
         if scheme:
             return scheme.execute_string_rm(code.strip())
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ coverage = [
     "coverage[toml]",
     "pytest-cov",
 ]
-typing = ["pip", "mypy", "ipywidgets"]
+typing = [{ include-group = "test-all" }, "pip", "mypy", "ipywidgets"]
 
 [tool.uv.sources]
 metakernel_python = { path = "./metakernel_python", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ disable_error_code = ["comparison-overlap", "no-untyped-def", "import-not-found"
 
 [[tool.mypy.overrides]]
 module = "metakernel.magics.*"
-disable_error_code = ["no-untyped-def", "no-untyped-call", "import-not-found"]
+disable_error_code = ["no-untyped-def"]
 
 [tool.ruff]
 exclude = ["examples/echo_kernel.ipynb"]

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -6,7 +6,7 @@ import pytest
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 try:
-    import ipyparallel
+    import ipyparallel  # type: ignore[import-untyped]
 except ImportError:
     ipyparallel = None
 

--- a/tests/magics/test_scheme_magic.py
+++ b/tests/magics/test_scheme_magic.py
@@ -24,7 +24,7 @@ def test_scheme_line_magic_define() -> None:
     asyncio.run(kernel.do_execute("%scheme (define x 42)", None))
     magic = kernel.line_magics["scheme"]
     # define statements return a void Symbol in calysto_scheme, not None
-    from calysto_scheme import scheme as cs
+    from calysto_scheme import scheme as cs  # type: ignore[import-untyped]
 
     assert magic.retval == cs.void_value
 

--- a/uv.lock
+++ b/uv.lock
@@ -2168,9 +2168,22 @@ test-all = [
     { name = "requests" },
 ]
 typing = [
+    { name = "calysto" },
+    { name = "calysto-scheme" },
+    { name = "ipyparallel" },
     { name = "ipywidgets" },
+    { name = "jupyter-kernel-test" },
+    { name = "matplotlib", version = "3.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "metakernel-python" },
     { name = "mypy" },
     { name = "pip" },
+    { name = "portalocker" },
+    { name = "pydot" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-timeout" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -2246,9 +2259,20 @@ test-all = [
     { name = "requests" },
 ]
 typing = [
+    { name = "calysto" },
+    { name = "calysto-scheme" },
+    { name = "ipyparallel" },
     { name = "ipywidgets" },
+    { name = "jupyter-kernel-test" },
+    { name = "matplotlib" },
+    { name = "metakernel-python", editable = "metakernel_python" },
     { name = "mypy" },
     { name = "pip" },
+    { name = "portalocker" },
+    { name = "pydot" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "requests" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a typed `get_ipython() -> InteractiveShell | None` helper to `metakernel.magic` (and re-exports from the top-level package alongside `option()`), wrapping `IPython.get_ipython()` with an explicit return type
- Replaces all inline `from IPython import get_ipython` usages in magics and `_metakernel.py` with the new helper
- Resolves all mypy errors across the magics package without disabling any error codes

**Key changes:**
- `magic.py` / `__init__.py` — new `get_ipython()` helper, exported publicly
- `_metakernel.py`, `brain_magic.py`, `pipe_magic.py`, `activity_magic.py` — switched to helper; added `None` guards where the result is now properly typed as optional
- `activity_magic.py` — added `assert self.results_filename is not None` before `portalocker.Lock()`
- `parallel_magic.py` — annotated `_clean_code()` with `(str) -> str`; `type: ignore` for `ipyparallel` and legacy `IPython.parallel.util` imports
- `scheme_magic.py` — annotated `eval()` with `(str) -> Any`; `type: ignore[import-untyped]` for `calysto_scheme`
- `dot_magic.py` — fixed pydot `None`/list handling; `type: ignore[attr-defined]` for `create_svg()` not in stubs
- Various display magics — `type: ignore[no-untyped-call]` on `HTML()`, `Javascript()`, `Latex()`, `FileLinks()`, `download()` call sites (IPython display objects lack stubs)
- `pyproject.toml` — removed `no-untyped-call` and `import-not-found` from the magics mypy override since all instances are now handled explicitly

## Test plan

- [x] `just typing` — zero mypy errors
- [x] `just test` — 345 passed, 4 skipped