### PR TITLE
Fix testpaths for newer pytest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ artifacts = ["metakernel/py.typed"]
 [tool.pytest.ini_options]
 minversion = "9.0"
 addopts= "-raXs  --durations 10 --color=yes --doctest-modules"
-testpaths = ["tests", "tests/magics"]
+testpaths = ["tests"]
 strict = true
 log_level = "INFO"
 timeout = 300


### PR DESCRIPTION
See: testpaths = A A/B doesn't test folder A
https://github.com/pytest-dev/pytest/issues/12605

Search is recursive, so in ["tests", "tests/magics"], the latter is redundant and can be removed. It is even harmful since in newer pytest versions parent directories of paths in testpaths are excluded, so listing "tests/magics" excludes the tests in "tests", and only the tests in "tests/magics" are run even though "tests" is listed in testpaths.