### PR TITLE
Add typed wrappers for register_line/cell_magic and annotate all magics

### DIFF
--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -181,6 +181,22 @@ def option(*args: Any, **kwargs: Any) -> Callable[[_F], _F]:
     return decorator
 
 
+def register_line_magic(func: _F) -> _F:
+    """Register a function as an IPython line magic, preserving its type."""
+    from IPython.core.magic import register_line_magic as _rlm
+
+    _rlm(func)
+    return func
+
+
+def register_cell_magic(func: _F) -> _F:
+    """Register a function as an IPython cell magic, preserving its type."""
+    from IPython.core.magic import register_cell_magic as _rcm
+
+    _rcm(func)
+    return func
+
+
 def _parse_args(
     func: Any, args: Any, usage: Any = None
 ) -> tuple[list[Any], dict[str, Any]]:

--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -351,9 +351,8 @@ def register_magics(kernel: MetaKernel) -> None:
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic, register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic, register_line_magic
     from metakernel.utils import add_docs
 
     kernel = IPythonKernel()

--- a/metakernel/magics/blockly_magic.py
+++ b/metakernel/magics/blockly_magic.py
@@ -2,9 +2,11 @@
 # Distributed under the terms of the Modified BSD License.
 # @author ChrisJaunes
 
+from __future__ import annotations
+
 from IPython.display import IFrame, Javascript
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class BlocklyMagic(Magic):
@@ -32,10 +34,10 @@ class BlocklyMagic(Magic):
     @option("-h", "--height", action="store", default=350, help="set height of iframe ")
     def line_blockly(
         self,
-        page_from_origin=None,
-        page_from_local=None,
-        template_data=None,
-        height=350,
+        page_from_origin: str | None = None,
+        page_from_local: str | None = None,
+        template_data: str | None = None,
+        height: int | None = 350,
     ) -> None:
         """
         %blockly - show visual code
@@ -105,14 +107,13 @@ class BlocklyMagic(Magic):
             )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(BlocklyMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_line_magic
 
     kernel = IPythonKernel()
     magic = BlocklyMagic(kernel)
@@ -120,7 +121,7 @@ def register_ipython_magics() -> None:
     kernel.line_magics["blockly"] = magic
 
     @register_line_magic
-    def blockly(line):
+    def blockly(line: str) -> None:
         """
         Use the blockly code visualizer and generator.
         """

--- a/metakernel/magics/brain_magic.py
+++ b/metakernel/magics/brain_magic.py
@@ -1,4 +1,4 @@
-from metakernel import Magic, get_ipython
+from metakernel import Magic, MetaKernel, get_ipython
 
 
 class BrainMagic(Magic):
@@ -24,20 +24,19 @@ def brain():
         self.code = pre_code + new_code + post_code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(BrainMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic
 
     kernel = IPythonKernel()
     magic = BrainMagic(kernel)
 
     @register_cell_magic
-    def brain(line, cell):
+    def brain(line: str, cell: str) -> None:
         ipkernel = get_ipython()
         if ipkernel is None:
             return

--- a/metakernel/magics/cd_magic.py
+++ b/metakernel/magics/cd_magic.py
@@ -4,11 +4,11 @@
 
 import os
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class CDMagic(Magic):
-    def line_cd(self, path=".") -> None:
+    def line_cd(self, path: str = ".") -> None:
         """
         %cd PATH - change current directory of session
 
@@ -32,5 +32,5 @@ class CDMagic(Magic):
             self.kernel.Print(retval)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(CDMagic)

--- a/metakernel/magics/connect_info_magic.py
+++ b/metakernel/magics/connect_info_magic.py
@@ -1,13 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
 import json
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class ConnectInfoMagic(Magic):
-    def line_connect_info(self, dummy=None) -> None:
+    def line_connect_info(self, dummy: str | None = None) -> None:
         """
         %connect_info - show connection information
 
@@ -69,5 +71,5 @@ if this is the most recent Jupyter session you have started.
         self.kernel.Print(retval)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ConnectInfoMagic)

--- a/metakernel/magics/conversation_magic.py
+++ b/metakernel/magics/conversation_magic.py
@@ -2,13 +2,15 @@
 Magics to have disqus conversation in the notebook.
 """
 
+from __future__ import annotations
+
 from IPython.display import HTML
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class ConversationMagic(Magic):
-    def cell_conversation(self, id) -> None:
+    def cell_conversation(self, id: str) -> None:
         """
         %conversation ID - insert conversation by ID
         %%conversation ID - insert conversation by ID
@@ -27,7 +29,7 @@ class ConversationMagic(Magic):
 """
         self.kernel.Display(HTML(html))  # type: ignore[no-untyped-call]
 
-    def line_conversation(self, id) -> None:
+    def line_conversation(self, id: str) -> None:
         """
         %conversation ID - insert conversation by ID
         %%conversation ID - insert conversation by ID
@@ -36,23 +38,22 @@ class ConversationMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ConversationMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic, register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic, register_line_magic
 
     kernel = IPythonKernel()
     magic = ConversationMagic(kernel)
 
     @register_line_magic
-    def conversation(id):
+    def conversation(id: str) -> None:
         magic.line_conversation(id)
 
     @register_cell_magic  # type: ignore[no-redef]
-    def conversation(id, cell):  # noqa: F811
+    def conversation(id: str, cell: str) -> None:  # noqa: F811
         magic.code = cell
         magic.cell_conversation(id)

--- a/metakernel/magics/debug_magic.py
+++ b/metakernel/magics/debug_magic.py
@@ -4,11 +4,11 @@
 
 from IPython.display import HTML, Javascript
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class DebugMagic(Magic):
-    def cell_debug(self, dummy) -> None:
+    def cell_debug(self, dummy: str) -> None:
         """
         %%debug - step through the code expression by expression
 
@@ -217,5 +217,5 @@ function reset() {
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(DebugMagic)

--- a/metakernel/magics/dot_magic.py
+++ b/metakernel/magics/dot_magic.py
@@ -4,11 +4,11 @@
 
 from IPython.display import HTML
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class DotMagic(Magic):
-    def line_dot(self, code) -> None:
+    def line_dot(self, code: str) -> None:
         """
         %dot CODE - render code as Graphviz image
 
@@ -59,20 +59,19 @@ class DotMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(DotMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic
 
     kernel = IPythonKernel()
     magic = DotMagic(kernel)
 
     @register_cell_magic
-    def dot(line, cell):
+    def dot(line: str, cell: str) -> None:
         """
         %%dot - evaluate cell contents as a dot diagram.
         """

--- a/metakernel/magics/download_magic.py
+++ b/metakernel/magics/download_magic.py
@@ -1,15 +1,15 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
-
+from __future__ import annotations
 
 import os
 import urllib.parse as urlparse
 import urllib.request
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
-def download(url, filename):
+def download(url: str, filename: str) -> None:
     g = urllib.request.urlopen(url)
     with open(filename, "wb") as f:
         f.write(g.read())
@@ -23,7 +23,7 @@ class DownloadMagic(Magic):
         default=None,
         help="use the provided name as filename",
     )
-    def line_download(self, url, filename=None) -> None:
+    def line_download(self, url: str, filename: str | None = None) -> None:
         """
         %download URL [-f FILENAME] - download file from URL
 
@@ -52,20 +52,19 @@ class DownloadMagic(Magic):
         filename = filename.replace("~", "")
         filename = filename.replace("%20", "_")
         try:
-            download(url, filename)  # type: ignore[no-untyped-call]
+            download(url, filename)
             self.kernel.Print(f"Downloaded '{filename}'.")
         except Exception as e:
             self.kernel.Error(str(e))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(DownloadMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_line_magic
 
     kernel = IPythonKernel()
     magic = DownloadMagic(kernel)
@@ -73,5 +72,5 @@ def register_ipython_magics() -> None:
     kernel.line_magics["download"] = magic
 
     @register_line_magic
-    def download(line):
+    def download(line: str) -> None:
         kernel.call_magic("%download " + line)

--- a/metakernel/magics/edit_magic.py
+++ b/metakernel/magics/edit_magic.py
@@ -4,11 +4,11 @@
 
 import os
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class EditMagic(Magic):
-    def line_edit(self, filename) -> None:
+    def line_edit(self, filename: str) -> None:
         """
         %edit FILENAME - load code from filename into next cell for editing
 
@@ -35,5 +35,5 @@ class EditMagic(Magic):
         )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(EditMagic)

--- a/metakernel/magics/file_magic.py
+++ b/metakernel/magics/file_magic.py
@@ -5,7 +5,7 @@
 import errno
 import os
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class FileMagic(Magic):
@@ -16,7 +16,7 @@ class FileMagic(Magic):
         default=False,
         help="append onto an existing file",
     )
-    def cell_file(self, filename, append=False) -> None:
+    def cell_file(self, filename: str, append: bool = False) -> None:
         """
         %%file [--append|-a] FILENAME - write contents of cell to file
 
@@ -60,5 +60,5 @@ class FileMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(FileMagic)

--- a/metakernel/magics/get_magic.py
+++ b/metakernel/magics/get_magic.py
@@ -1,11 +1,13 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic
+from typing import Any
+
+from metakernel import Magic, MetaKernel
 
 
 class GetMagic(Magic):
-    def line_get(self, variable) -> None:
+    def line_get(self, variable: str) -> None:
         """
         %get VARIABLE - get a variable from the kernel in a Python-type.
 
@@ -16,9 +18,9 @@ class GetMagic(Magic):
         """
         self.retval = self.kernel.get_variable(variable)
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(GetMagic)

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -2,11 +2,13 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-from metakernel import Magic
+from __future__ import annotations
+
+from metakernel import Magic, MetaKernel
 
 
 class HelpMagic(Magic):
-    def help_strings(self):
+    def help_strings(self) -> list[str]:
         suffixes = [
             "item{0}{0} - get detailed, technical information on item",
             "item{0}  - get help on item",
@@ -136,5 +138,5 @@ class HelpMagic(Magic):
         return text
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(HelpMagic)

--- a/metakernel/magics/html_magic.py
+++ b/metakernel/magics/html_magic.py
@@ -4,11 +4,11 @@
 
 from IPython.display import HTML
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class HTMLMagic(Magic):
-    def line_html(self, code) -> None:
+    def line_html(self, code: str) -> None:
         """
         %html CODE - display code as HTML
 
@@ -41,5 +41,5 @@ class HTMLMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(HTMLMagic)

--- a/metakernel/magics/include_magic.py
+++ b/metakernel/magics/include_magic.py
@@ -4,11 +4,11 @@
 import os
 import shlex
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class IncludeMagic(Magic):
-    def line_include(self, filenames) -> None:
+    def line_include(self, filenames: str) -> None:
         """
         %include FILENAME ... - include code from filename into this code
 
@@ -29,12 +29,12 @@ class IncludeMagic(Magic):
             parts = shlex.split(filenames, posix=False)
         except ValueError:
             parts = filenames.split()
-        filenames = [
+        file_list = [
             p[1:-1] if len(p) >= 2 and p[0] == p[-1] and p[0] in ("'", '"') else p
             for p in parts
         ]
         prefix = self.kernel.magic_prefixes["magic"]
-        for filename in filenames:
+        for filename in file_list:
             if filename.startswith("~"):
                 filename = os.path.expanduser(filename)
             filename = os.path.abspath(filename)
@@ -56,5 +56,5 @@ class IncludeMagic(Magic):
             self.code = text + self.code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(IncludeMagic)

--- a/metakernel/magics/install_magic.py
+++ b/metakernel/magics/install_magic.py
@@ -3,11 +3,11 @@
 
 import os
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class InstallMagic(Magic):
-    def line_install(self, package) -> None:
+    def line_install(self, package: str) -> None:
         """
         %install PACKAGE - install package
 
@@ -37,7 +37,7 @@ class InstallMagic(Magic):
         ## // To turn off automatically creating closing parenthesis and bracket:
         ## IPython.CodeCell.options_default.cm_config["autoCloseBrackets"] = "";
 
-    def enable_extension(self, name) -> None:
+    def enable_extension(self, name: str) -> None:
         filename = "~/.ipython/profile_default/static/custom/custom.js"
         if filename.startswith("~"):
             filename = os.path.expanduser(filename)
@@ -63,5 +63,5 @@ require(["base/js/events"], function (events) {
             fp.write(text)
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(InstallMagic)

--- a/metakernel/magics/install_magic_magic.py
+++ b/metakernel/magics/install_magic_magic.py
@@ -5,17 +5,17 @@ import os
 import urllib.parse as urlparse
 import urllib.request
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
-def download(url, filename):
+def download(url: str, filename: str) -> None:
     g = urllib.request.urlopen(url)
     with open(filename, "wb") as f:
         f.write(g.read())
 
 
 class InstallMagicMagic(Magic):
-    def line_install_magic(self, url) -> None:
+    def line_install_magic(self, url: str) -> None:
         """
         %install_magic URL - download and install magic from URL
 
@@ -32,12 +32,12 @@ class InstallMagicMagic(Magic):
         filename = os.path.basename(path)
         magic_filename = os.path.join(self.kernel.get_local_magics_dir(), filename)
         try:
-            download(url, magic_filename)  # type: ignore[no-untyped-call]
+            download(url, magic_filename)
             self.kernel.Print(f"Downloaded '{magic_filename}'.")
             self.code = "%reload_magics\n" + self.code
         except Exception as e:
             self.kernel.Error(str(e))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(InstallMagicMagic)

--- a/metakernel/magics/javascript_magic.py
+++ b/metakernel/magics/javascript_magic.py
@@ -3,11 +3,11 @@
 
 from IPython.display import Javascript
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class JavascriptMagic(Magic):
-    def line_javascript(self, code) -> None:
+    def line_javascript(self, code: str) -> None:
         """
         %javascript CODE - send code as JavaScript
 
@@ -40,5 +40,5 @@ class JavascriptMagic(Magic):
             self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(JavascriptMagic)

--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -1,5 +1,6 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import random
 import string
@@ -7,14 +8,14 @@ import urllib.request
 
 from IPython.display import IFrame, Javascript
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 urlopen = urllib.request.urlopen
 
 
-def download(url):
+def download(url: str) -> str:
     g = urlopen(url)
-    return g.read().decode("utf-8")
+    return g.read().decode("utf-8")  # type: ignore[no-any-return]
 
 
 class JigsawMagic(Magic):
@@ -26,7 +27,9 @@ class JigsawMagic(Magic):
         help="use the provided name as workspace filename",
     )
     @option("-h", "--height", action="store", default=350, help="set height of iframe ")
-    def line_jigsaw(self, language, workspace=None, height=350) -> None:
+    def line_jigsaw(
+        self, language: str, workspace: str | None = None, height: int = 350
+    ) -> None:
         """
         %jigsaw LANGUAGE - show visual code editor/generator
 
@@ -47,7 +50,7 @@ class JigsawMagic(Magic):
                 )
             )
         workspace_filename = workspace + ".xml"
-        html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")  # type: ignore[no-untyped-call]
+        html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")
         html_filename = workspace + ".html"
         html_text = html_text.replace("MYWORKSPACENAME", workspace_filename)
         with open(html_filename, "w") as fp:
@@ -195,14 +198,13 @@ class JigsawMagic(Magic):
         self.kernel.Display(IFrame(html_filename, width="100%", height=height))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(JigsawMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_line_magic
 
     kernel = IPythonKernel()
     magic = JigsawMagic(kernel)
@@ -210,7 +212,7 @@ def register_ipython_magics() -> None:
     kernel.line_magics["jigsaw"] = magic
 
     @register_line_magic
-    def jigsaw(line):
+    def jigsaw(line: str) -> None:
         """
         Use the Jigsaw code visualizer and generator.
         """

--- a/metakernel/magics/kernel_magic.py
+++ b/metakernel/magics/kernel_magic.py
@@ -1,10 +1,11 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import importlib
 from typing import Any
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class KernelMagic(Magic):
@@ -18,7 +19,9 @@ class KernelMagic(Magic):
         default="default",
         help="kernel name given to use for execution",
     )
-    def line_kernel(self, module_name, class_name, kernel_name="default") -> None:
+    def line_kernel(
+        self, module_name: str, class_name: str, kernel_name: str = "default"
+    ) -> None:
         """
         %kernel MODULE CLASS [-k NAME] - construct a kernel for sending code.
 
@@ -50,7 +53,7 @@ class KernelMagic(Magic):
         default=None,
         help="kernel name given to use for execution",
     )
-    def cell_kx(self, kernel_name=None) -> None:
+    def cell_kx(self, kernel_name: str | None = None) -> None:
         """
         %%kx [-k NAME] - send the cell code to the kernel.
 
@@ -69,7 +72,7 @@ class KernelMagic(Magic):
         """
         if kernel_name is None:
             kernel_name = self.kernel_name
-        self.retval = self.kernels[kernel_name].do_execute_direct(self.code)
+        self.retval = self.kernels[kernel_name].do_execute_direct(self.code)  # type: ignore[index]
         self.evaluate = False
 
     @option(
@@ -79,7 +82,7 @@ class KernelMagic(Magic):
         default=None,
         help="kernel name given to use for execution",
     )
-    def line_kx(self, code, kernel_name=None) -> None:
+    def line_kx(self, code: str, kernel_name: str | None = None) -> None:
         """
         %kx CODE [-k NAME] - send the code to the kernel.
 
@@ -98,26 +101,25 @@ class KernelMagic(Magic):
             kernel_name = self.kernel_name
         # make sure the code is sent as a string for execution
         code = str(code)
-        self.retval = self.kernels[kernel_name].do_execute_direct(code)
+        self.retval = self.kernels[kernel_name].do_execute_direct(code)  # type: ignore[index]
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(KernelMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic, register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic, register_line_magic
 
     kernel = IPythonKernel()
     magic = KernelMagic(kernel)
 
     @register_line_magic  # type: ignore[no-redef]
-    def kernel(line):
+    def kernel(line: str) -> None:
         """
         line is module_name, class_name[, kernel_name]
         """
@@ -133,7 +135,7 @@ def register_ipython_magics() -> None:
         magic.line_kernel(module_name, class_name, kernel_name)
 
     @register_cell_magic
-    def kx(line, cell):
+    def kx(line: str, cell: str) -> None:
         """
         line is kernel_name, or "default"
         """

--- a/metakernel/magics/latex_magic.py
+++ b/metakernel/magics/latex_magic.py
@@ -3,11 +3,11 @@
 
 from IPython.display import Latex
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class LatexMagic(Magic):
-    def line_latex(self, text) -> None:
+    def line_latex(self, text: str) -> None:
         r"""
         %latex TEXT - display text as LaTeX
 
@@ -37,5 +37,5 @@ class LatexMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(LatexMagic)

--- a/metakernel/magics/load_magic.py
+++ b/metakernel/magics/load_magic.py
@@ -3,11 +3,11 @@
 
 import os
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class LoadMagic(Magic):
-    def line_load(self, filename) -> None:
+    def line_load(self, filename: str) -> None:
         """
         %load FILENAME - load code from filename into next cell
 
@@ -24,5 +24,5 @@ class LoadMagic(Magic):
             self.kernel.payload.append({"source": "set_next_input", "text": f.read()})
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(LoadMagic)

--- a/metakernel/magics/ls_magic.py
+++ b/metakernel/magics/ls_magic.py
@@ -2,10 +2,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+from typing import Any
 
 from IPython.display import FileLinks
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class LSMagic(Magic):
@@ -16,7 +17,7 @@ class LSMagic(Magic):
         default=False,
         help="recursively descend into subdirectories",
     )
-    def line_ls(self, path=".", recursive=False) -> None:
+    def line_ls(self, path: str = ".", recursive: bool = False) -> None:
         """
         %ls PATH - list files and directories under PATH
 
@@ -29,9 +30,9 @@ class LSMagic(Magic):
         path = os.path.expanduser(path)
         self.retval = FileLinks(path, recursive=recursive)  # type: ignore[no-untyped-call]
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(LSMagic)

--- a/metakernel/magics/lsmagic_magic.py
+++ b/metakernel/magics/lsmagic_magic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class LSMagicMagic(Magic):
@@ -30,5 +30,5 @@ class LSMagicMagic(Magic):
         self.kernel.Print("\n".join(out))
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(LSMagicMagic)

--- a/metakernel/magics/macro_magic.py
+++ b/metakernel/magics/macro_magic.py
@@ -4,8 +4,9 @@
 import ast
 import inspect
 import os
+from typing import Any
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class MacroMagic(Magic):
@@ -25,7 +26,7 @@ class MacroMagic(Magic):
 """
     }
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._load_macros()
 
@@ -38,7 +39,9 @@ class MacroMagic(Magic):
     )
     @option("-l", "--list", action="store_true", default=False, help="list macros")
     @option("-s", "--show", action="store_true", default=False, help="show macro")
-    def line_macro(self, name, delete=False, list=False, show=False) -> None:
+    def line_macro(
+        self, name: str, delete: bool = False, list: bool = False, show: bool = False
+    ) -> None:
         """
         %macro NAME - execute a macro
         %macro -l [all|learned|system] - list macros
@@ -89,7 +92,9 @@ class MacroMagic(Magic):
             self._list_macros(retval=f"No such macro: '{name}'\n\n", error=True)
         self.evaluate = True
 
-    def _list_macros(self, name="all", retval="", error=False) -> None:
+    def _list_macros(
+        self, name: str = "all", retval: str = "", error: bool = False
+    ) -> None:
         retval += "Available macros:\n"
         if name in ["all", "system"]:
             retval += "    System:\n"
@@ -130,7 +135,7 @@ class MacroMagic(Magic):
         with open(filename, "w") as macros:
             macros.write(str(self.learned))
 
-    def cell_macro(self, name) -> None:
+    def cell_macro(self, name: str) -> None:
         """
         %%macro NAME - learn a new macro
 
@@ -150,5 +155,5 @@ class MacroMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(MacroMagic)

--- a/metakernel/magics/magic_magic.py
+++ b/metakernel/magics/magic_magic.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class MagicMagic(Magic):
-    def line_magic(self, line) -> None:
+    def line_magic(self, line: str) -> None:
         """
         %magic - show installed magics
 
@@ -52,7 +52,7 @@ class MagicMagic(Magic):
             self.kernel.Print("    " + string)
         self.kernel.Print("")
 
-    def get_magic(self, info, get_args=False) -> Any:
+    def get_magic(self, info: dict[str, Any], get_args: bool = False) -> Any:
 
         if not info["magic"]:
             return None
@@ -90,5 +90,5 @@ class MagicMagic(Magic):
             )
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(MagicMagic)

--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class Slice:
     """Utility class for making slice ranges."""
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> Any:
         return item
 
 
@@ -44,7 +44,11 @@ class ParallelMagic(Magic):
         help="the machine ids to use from the cluster",
     )
     def line_parallel(
-        self, module_name, class_name, kernel_name="default", ids=None
+        self,
+        module_name: str,
+        class_name: str,
+        kernel_name: str = "default",
+        ids: str | None = None,
     ) -> None:
         """
         %parallel MODULE CLASS [-k NAME] [-i [...]] - construct an interface to the cluster.
@@ -186,7 +190,11 @@ kernels['{kernel_name}'] = {class_name}()
         help="set the variable with the parallel results rather than returning them",
     )
     def line_px(
-        self, expression, kernel_name=None, evaluate=False, set_variable=None
+        self,
+        expression: str,
+        kernel_name: str | None = None,
+        evaluate: bool = False,
+        set_variable: str | None = None,
     ) -> None:
         """
         %px EXPRESSION - send EXPRESSION to the cluster.
@@ -266,7 +274,12 @@ kernels['{kernel_name}'] = {class_name}()
         default=None,
         help="set the variable with the parallel results rather than returning them",
     )
-    def cell_px(self, kernel_name=None, evaluate=False, set_variable=None) -> None:
+    def cell_px(
+        self,
+        kernel_name: str | None = None,
+        evaluate: bool = False,
+        set_variable: str | None = None,
+    ) -> None:
         """
         %%px - send cell to the cluster.
 
@@ -297,7 +310,11 @@ kernels['{kernel_name}'] = {class_name}()
         help="set the variable with the parallel results rather than returning them",
     )
     def line_pmap(
-        self, function_name, args, kernel_name=None, set_variable=None
+        self,
+        function_name: str,
+        args: str,
+        kernel_name: str | None = None,
+        set_variable: str | None = None,
     ) -> None:
         """
         %pmap FUNCTION [ARGS1,ARGS2,...] - ("parallel map") call a FUNCTION on args
@@ -358,7 +375,7 @@ kernels['{kernel_name}'] = {class_name}()
             self.kernel.set_variable(set_variable, results)
             self.retval = None
 
-    def post_process(self, retval) -> Any:
+    def post_process(self, retval: Any) -> Any:
         try:
             ## any will crash on numpy arrays
             if isinstance(self.retval, list) and not any(self.retval):
@@ -368,5 +385,5 @@ kernels['{kernel_name}'] = {class_name}()
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ParallelMagic)

--- a/metakernel/magics/pipe_magic.py
+++ b/metakernel/magics/pipe_magic.py
@@ -1,14 +1,16 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic, get_ipython
+from typing import Any
+
+from metakernel import Magic, MetaKernel, get_ipython
 
 
 class PipeMagic(Magic):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    def cell_pipe(self, pipe_str) -> None:
+    def cell_pipe(self, pipe_str: str) -> None:
         """
         %%pipe FUNCTION1 | FUNCTION2 ...
 
@@ -32,19 +34,19 @@ class PipeMagic(Magic):
             self.retval = self.kernel.do_function_direct(function, self.retval)
         self.evaluate = False
 
-    def post_process(self, retval) -> str:
+    def post_process(self, retval: Any) -> Any:
         return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(PipeMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic
+    from metakernel.magic import register_cell_magic
 
     @register_cell_magic
-    def pipe(line, cell):
+    def pipe(line: str, cell: str) -> Any:
         """ """
         ip = get_ipython()
         if ip is None:

--- a/metakernel/magics/plot_magic.py
+++ b/metakernel/magics/plot_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic, option
+from typing import Any
+
+from metakernel import Magic, MetaKernel, option
 
 
 class PlotMagic(Magic):
@@ -13,7 +15,7 @@ class PlotMagic(Magic):
     @option("-r", "--resolution", action="store", help="Resolution in pixels per inch")
     @option("-w", "--width", action="store", help="Plot width in pixels")
     @option("-h", "--height", action="store", help="Plot height in pixels")
-    def line_plot(self, *args, **kwargs) -> None:
+    def line_plot(self, *args: Any, **kwargs: Any) -> None:
         """
         %plot [options] backend - configure plotting for the session.
 
@@ -41,5 +43,5 @@ class PlotMagic(Magic):
         self.kernel.handle_plot_settings()
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(PlotMagic)

--- a/metakernel/magics/processing_magic.py
+++ b/metakernel/magics/processing_magic.py
@@ -1,15 +1,17 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import annotations
+
 from IPython.display import HTML
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class ProcessingMagic(Magic):
     canvas_id = 0
 
-    def cell_processing(self, dummy=None) -> None:
+    def cell_processing(self, dummy: str | None = None) -> None:
         """
         %%processing - run the cell in the language Processing
 
@@ -48,20 +50,19 @@ require([window.location.protocol + "//calysto.github.io/javascripts/processing/
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ProcessingMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic
 
     kernel = IPythonKernel()
     magic = ProcessingMagic(kernel)
 
     @register_cell_magic
-    def processing(line, cell):
+    def processing(line: str, cell: str) -> None:
         """ """
         magic.code = cell
         magic.cell_processing()

--- a/metakernel/magics/reload_magics_magic.py
+++ b/metakernel/magics/reload_magics_magic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class ReloadMagicsMagic(Magic):
@@ -22,5 +22,5 @@ class ReloadMagicsMagic(Magic):
         self.code = "%lsmagic\n" + self.code
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ReloadMagicsMagic)

--- a/metakernel/magics/restart_magic.py
+++ b/metakernel/magics/restart_magic.py
@@ -3,7 +3,7 @@
 
 import json
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class RestartMagic(Magic):
@@ -29,5 +29,5 @@ class RestartMagic(Magic):
         kernel.Print("Done!")
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(RestartMagic)

--- a/metakernel/magics/run_magic.py
+++ b/metakernel/magics/run_magic.py
@@ -1,9 +1,10 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
 
 import os
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class RunMagic(Magic):
@@ -14,7 +15,7 @@ class RunMagic(Magic):
         default=None,
         help="use the provided language name as kernel",
     )
-    def line_run(self, filename, language=None) -> None:
+    def line_run(self, filename: str, language: str | None = None) -> None:
         """
         %run [--language LANG] FILENAME - run code in filename by
            kernel
@@ -48,5 +49,5 @@ class RunMagic(Magic):
                 self.code += "".join(f.readlines())
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(RunMagic)

--- a/metakernel/magics/scheme_magic.py
+++ b/metakernel/magics/scheme_magic.py
@@ -3,7 +3,7 @@
 
 from typing import Any
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 try:
     from calysto_scheme import scheme  # type: ignore[import-untyped]
@@ -12,11 +12,11 @@ except ImportError:
 
 
 class SchemeMagic(Magic):
-    def __init__(self, kernel) -> None:
+    def __init__(self, kernel: MetaKernel) -> None:
         super().__init__(kernel)
         self.retval = None
 
-    def line_scheme(self, *args) -> None:
+    def line_scheme(self, *args: str) -> None:
         """
         %scheme CODE - evaluate code as Scheme
 
@@ -45,7 +45,7 @@ class SchemeMagic(Magic):
         default=False,
         help="Use the retval value from the Scheme cell as code in the kernel language.",
     )
-    def cell_scheme(self, eval_output=False) -> None:
+    def cell_scheme(self, eval_output: bool = False) -> None:
         """
         %%scheme - evaluate contents of cell as Scheme
 
@@ -78,32 +78,31 @@ class SchemeMagic(Magic):
                 self.retval = self.eval(self.code)
                 self.evaluate = False
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         if retval is not None:
             return retval
         else:
             return self.retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(SchemeMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic, register_line_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic, register_line_magic
 
     kernel = IPythonKernel()
     magic = SchemeMagic(kernel)
 
     @register_line_magic
-    def scheme(line):
+    def scheme(line: str) -> Any:
         magic.line_scheme(line)
         return magic.retval
 
     @register_cell_magic  # type: ignore[no-redef]
-    def scheme(line, cell):  # noqa: F811
+    def scheme(line: str, cell: str) -> Any:  # noqa: F811
         magic.code = cell
         magic.cell_scheme()
         return magic.retval

--- a/metakernel/magics/set_magic.py
+++ b/metakernel/magics/set_magic.py
@@ -1,11 +1,13 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic
+from typing import Any
+
+from metakernel import Magic, MetaKernel
 
 
 class SetMagic(Magic):
-    def line_set(self, variable, value) -> None:
+    def line_set(self, variable: str, value: str) -> None:
         """
         %set VARIABLE VALUE - set a variable in the kernel.
 
@@ -18,9 +20,9 @@ class SetMagic(Magic):
         value = self.kernel.do_execute_direct(value)
         self.kernel.set_variable(variable, value)
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         return retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(SetMagic)

--- a/metakernel/magics/shell_magic.py
+++ b/metakernel/magics/shell_magic.py
@@ -6,18 +6,18 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from metakernel import Magic, pexpect
+from metakernel import Magic, MetaKernel, pexpect
 from metakernel.replwrap import REPLWrapper, bash, powershell
 
 
 class ShellMagic(Magic):
-    def __init__(self, kernel) -> None:
+    def __init__(self, kernel: MetaKernel) -> None:
         super().__init__(kernel)
         self.repl: REPLWrapper | None = None
         self.cmd: str | None = None
         self.start_process()
 
-    def line_shell(self, *args) -> None:
+    def line_shell(self, *args: str) -> None:
         """
         %shell COMMAND - run the line as a shell command
 
@@ -48,7 +48,7 @@ class ShellMagic(Magic):
         if os.path.exists(cwd):
             os.chdir(cwd)
 
-    def eval(self, cmd, incremental=False) -> str:
+    def eval(self, cmd: str, incremental: bool = False) -> str:
         assert self.repl is not None
         stream_handler = self.kernel.Print if incremental else None
         return self.repl.run_command(cmd, timeout=None, stream_handler=stream_handler)
@@ -91,7 +91,7 @@ class ShellMagic(Magic):
         self.line_shell(self.code)
         self.evaluate = False
 
-    def get_completions(self, info) -> list[str]:
+    def get_completions(self, info: dict[str, Any]) -> list[str]:
         if self.cmd == "cmd":
             return []
         command = 'compgen -cdfa "{}"'.format(info["code"])
@@ -112,5 +112,5 @@ class ShellMagic(Magic):
             return f"Sorry, no help is available on '{expr}'."
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ShellMagic)

--- a/metakernel/magics/show_magic.py
+++ b/metakernel/magics/show_magic.py
@@ -1,7 +1,9 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic, option
+from typing import Any
+
+from metakernel import Magic, MetaKernel, option
 
 
 class ShowMagic(Magic):
@@ -12,7 +14,7 @@ class ShowMagic(Magic):
         default=False,
         help="rather than showing the contents, show the results",
     )
-    def cell_show(self, output=False) -> None:
+    def cell_show(self, output: bool = False) -> None:
         """
         %%show [-o]- show cell contents or results in system pager
 
@@ -39,7 +41,7 @@ class ShowMagic(Magic):
         else:
             self.evaluate = True
 
-    def post_process(self, results) -> None:
+    def post_process(self, results: Any) -> None:
         if self.show_output:
             self.kernel.payload = [
                 {
@@ -51,5 +53,5 @@ class ShowMagic(Magic):
         return None
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(ShowMagic)

--- a/metakernel/magics/time_magic.py
+++ b/metakernel/magics/time_magic.py
@@ -2,8 +2,9 @@
 # Distributed under the terms of the Modified BSD License.
 
 import time
+from typing import Any
 
-from metakernel import Magic
+from metakernel import Magic, MetaKernel
 
 
 class TimeMagic(Magic):
@@ -23,12 +24,12 @@ class TimeMagic(Magic):
         """
         self.start = time.time()
 
-    def post_process(self, retval):
+    def post_process(self, retval: Any) -> Any:
         if self.code.strip():
             result = "Time: %s seconds.\n" % (time.time() - self.start)
             self.kernel.Print(result)
         return retval
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(TimeMagic)

--- a/metakernel/magics/tutor_magic.py
+++ b/metakernel/magics/tutor_magic.py
@@ -6,6 +6,8 @@ tutormagic
 Magics to display pythontutor.com in the notebook.
 """
 
+from __future__ import annotations
+
 # Based on Kiko Correoso's IPython magic:
 # https://github.com/kikocorreoso/tutormagic
 # and Doug Blank's
@@ -19,12 +21,11 @@ Magics to display pythontutor.com in the notebook.
 # Contributors:
 #   kikocorreoso
 # -----------------------------------------------------------------------------
-
 from urllib.parse import quote
 
 from IPython.display import IFrame
 
-from metakernel import Magic, option
+from metakernel import Magic, MetaKernel, option
 
 
 class TutorMagic(Magic):
@@ -38,7 +39,7 @@ class TutorMagic(Magic):
             + "Possible values are: python, python2, python3, java, javascript"
         ),
     )
-    def cell_tutor(self, language=None) -> None:
+    def cell_tutor(self, language: str | None = None) -> None:
         """
         %%tutor [--language=LANGUAGE] - show cell with
         Online Python Tutor.
@@ -92,19 +93,18 @@ class TutorMagic(Magic):
         self.evaluate = False
 
 
-def register_magics(kernel) -> None:
+def register_magics(kernel: MetaKernel) -> None:
     kernel.register_magics(TutorMagic)
 
 
 def register_ipython_magics() -> None:
-    from IPython.core.magic import register_cell_magic
-
     from metakernel import IPythonKernel
+    from metakernel.magic import register_cell_magic
 
     kernel = IPythonKernel()
     magic = TutorMagic(kernel)
 
     @register_cell_magic
-    def tutor(line, cell):
+    def tutor(line: str, cell: str) -> None:
         magic.code = cell
         magic.cell_tutor(language="python3")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,10 +120,6 @@ module = "tests.*"
 disallow_untyped_defs = false
 disable_error_code = ["comparison-overlap", "no-untyped-def", "import-not-found", "no-untyped-call"]
 
-[[tool.mypy.overrides]]
-module = "metakernel.magics.*"
-disable_error_code = ["no-untyped-def"]
-
 [tool.ruff]
 exclude = ["examples/echo_kernel.ipynb"]
 


### PR DESCRIPTION
## Summary

- Add `register_line_magic()` and `register_cell_magic()` typed wrappers to `magic.py` using `TypeVar` to preserve the decorated function's type (matching the `option()` pattern)
- Add full type annotations to all 35+ magic files in `metakernel/magics/`, covering `register_magics`, magic methods, `post_process`, `__init__`, and inner IPython callback functions
- Remove the mypy override that suppressed `no-untyped-def` errors for the magics package — mypy now reports `Success: no issues found in 112 source files`
- Fix misplaced `from __future__ import annotations` in `blockly_magic.py`, `processing_magic.py`, and `tutor_magic.py` (must appear before other imports)

## Test plan

- [x] `just typing` — no mypy errors
- [x] `just test` — 345 passed, 4 skipped (matches baseline)