### PR TITLE
Add type annotations to test helpers and resolve mypy errors

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -101,7 +101,7 @@ class MetaKernel(Kernel):
         # 'file_extension': '.py',
         "help_links": help_links,
     }
-    plot_settings = Dict(dict(backend="inline")).tag(config=True)
+    plot_settings: dict[str, Any] = Dict(dict(backend="inline")).tag(config=True)  # type: ignore[assignment]
 
     meta_kernel = None
 
@@ -139,9 +139,9 @@ class MetaKernel(Kernel):
         self._i: str | None = None
         self._ii: str | None = None
         self._iii: str | None = None
-        self._: str | None = None
-        self.__: str | None = None
-        self.___: str | None = None
+        self._: Any = None
+        self.__: Any = None
+        self.___: Any = None
         self.max_hist_cache = 1000
         self.hist_cache: list[str] = []
         kwargs = {"parent": self, "kernel": self}
@@ -844,6 +844,9 @@ class MetaKernel(Kernel):
 
 class MetaKernelApp(IPKernelApp):
     """The MetaKernel launcher application."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)  # type:ignore[no-untyped-call]
 
     config_dir = Unicode()
 

--- a/tests/magics/test_install_magic.py
+++ b/tests/magics/test_install_magic.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -15,12 +16,17 @@ pytestmark = [
     pytest.mark.filterwarnings("ignore::ResourceWarning"),
 ]
 
+from metakernel import MetaKernel
 from tests.utils import get_kernel
 
 _CUSTOM_JS_TILDE = "~/.ipython/profile_default/static/custom/custom.js"
 
 
-def _setup(tmp_path, monkeypatch, initial_content=""):
+def _setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    initial_content: str = "",
+) -> tuple[MetaKernel, Path, list[str]]:
     """Return (kernel, custom_js_path, inner_calls).
 
     The shell magic's line_shell is wrapped so that calls are captured in
@@ -40,11 +46,9 @@ def _setup(tmp_path, monkeypatch, initial_content=""):
     kernel = get_kernel()
     inner_calls: list[str] = []
     shell_magic = kernel.line_magics["shell"]
-    original_line_shell = shell_magic.line_shell
 
-    def capturing_line_shell(command, *args, **kwargs):
+    def capturing_line_shell(command: str, *args: str) -> None:
         inner_calls.append("!" + command)
-        return None
 
     shell_magic.line_shell = capturing_line_shell
     return kernel, custom_js, inner_calls

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -1,8 +1,10 @@
 import asyncio
 import sys
+from typing import Any
 
 import pytest
 
+from metakernel.magics.parallel_magic import ParallelMagic
 from tests.utils import EvalKernel, get_kernel, get_log_text
 
 try:
@@ -47,40 +49,40 @@ def test_parallel_magic() -> None:
 class MockView:
     """Minimal stand-in for an ipyparallel view."""
 
-    def __init__(self):
-        self.executed = []
+    def __init__(self) -> None:
+        self.executed: list[str] = []
 
-    def execute(self, code, block=False):
+    def execute(self, code: str, block: bool = False) -> None:
         self.executed.append(code)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> None:
         return None
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: Any) -> None:
         pass
 
-    def scatter(self, name, values, flatten=False):
+    def scatter(self, name: str, values: Any, flatten: bool = False) -> None:
         pass
 
-    def append(self, other):
+    def append(self, other: Any) -> None:
         pass
 
 
 class MockClient:
     """Stand-in for ipyparallel.Client that records how views were requested."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.ids = [0, 1, 2]
-        self.accessed_with = []
+        self.accessed_with: list[Any] = []
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Any) -> MockView:
         self.accessed_with.append(item)
         return MockView()
 
-    def load_balanced_view(self):
+    def load_balanced_view(self) -> MockView:
         return MockView()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.ids)
 
 
@@ -220,14 +222,19 @@ def test_line_parallel_ids_sets_cluster_variables_on_kernel(monkeypatch) -> None
 class _PxView:
     """MockView whose __getitem__ can return a value or raise an exception."""
 
-    def __init__(self, return_value=None, raises=None, fail_times=0):
-        self.called_with = []
+    def __init__(
+        self,
+        return_value: Any = None,
+        raises: BaseException | None = None,
+        fail_times: int = 0,
+    ) -> None:
+        self.called_with: list[Any] = []
         self._return_value = return_value
         self._raises = raises
         self._fail_times = fail_times  # raise on first N calls, then succeed
         self._call_count = 0
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> Any:
         self._call_count += 1
         self.called_with.append(key)
         if self._raises is not None:
@@ -235,19 +242,19 @@ class _PxView:
                 raise self._raises
         return self._return_value
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: Any) -> None:
         pass
 
-    def execute(self, code, block=False):
+    def execute(self, code: str, block: bool = False) -> None:
         pass
 
-    def scatter(self, name, values, flatten=False):
+    def scatter(self, name: str, values: Any, flatten: bool = False) -> None:
         pass
 
 
-def _make_px_magic(view=None, kernel_name="default"):
-    from metakernel.magics.parallel_magic import ParallelMagic
-
+def _make_px_magic(
+    view: _PxView | None = None, kernel_name: str = "default"
+) -> ParallelMagic:
     kernel = get_kernel(EvalKernel)
     magic = ParallelMagic(kernel)
     magic.view = view if view is not None else _PxView()
@@ -428,18 +435,18 @@ def test_cell_px_evaluate_false_sets_evaluate_flag() -> None:
 class _LoadBalancedView:
     """Mock for an ipyparallel load-balanced view."""
 
-    def __init__(self, return_value=None):
-        self.map_async_calls = []
+    def __init__(self, return_value: Any = None) -> None:
+        self.map_async_calls: list[tuple[Any, list[Any]]] = []
         self._return_value = return_value
 
-    def map_async(self, f, args):
+    def map_async(self, f: Any, args: Any) -> Any:
         self.map_async_calls.append((f, list(args)))
         return self._return_value
 
 
-def _make_pmap_magic(lb_view=None, kernel_name="default"):
-    from metakernel.magics.parallel_magic import ParallelMagic
-
+def _make_pmap_magic(
+    lb_view: _LoadBalancedView | None = None, kernel_name: str = "default"
+) -> ParallelMagic:
     kernel = get_kernel(EvalKernel)
     magic = ParallelMagic(kernel)
     magic.view_load_balanced = lb_view if lb_view is not None else _LoadBalancedView()

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -271,13 +271,13 @@ def test_async_do_execute_direct() -> None:
 
 def test_misc() -> None:
     class TestKernel(MetaKernel):
-        def do_execute_file(self, filename):
+        def do_execute_file(self, filename: str) -> None:
             self.Print("This language does not support running files")
 
-        def do_function_direct(self, f, arg):
+        def do_function_direct(self, f: str, arg: Any) -> None:
             self.Print("%s(%s)" % (f, self.repr(arg)))
 
-        def repr(self, arg):
+        def repr(self, arg: Any) -> str:
             return "XXX"
 
     kernel = get_kernel(TestKernel)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import logging
+from io import StringIO
+from logging import Logger, StreamHandler
 from typing import Any, TypeVar, overload
+
+import zmq
+from jupyter_client import session as ss
 
 from metakernel import MetaKernel
 
@@ -15,20 +21,6 @@ __all__ = [
 
 _KT = TypeVar("_KT", bound=MetaKernel)
 
-try:
-    from jupyter_client import session as ss
-except ImportError:
-    from IPython.kernel.zmq import session as ss  # type: ignore[no-redef]
-import logging
-from logging import Logger, StreamHandler
-
-import zmq
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 
 class EvalKernel(MetaKernel):
     implementation = "Eval"
@@ -37,25 +29,25 @@ class EvalKernel(MetaKernel):
     language_version = "0.1"
     banner = "Eval kernel - evaluates simple Python statements and expressions"
 
-    def set_variable(self, name, value) -> None:
+    def set_variable(self, name: str, value: Any) -> None:
         """
         Set a variable in the kernel language.
         """
         python_magic = self.line_magics["python"]
         python_magic.env[name] = value
 
-    def get_variable(self, name):
+    def get_variable(self, name: str) -> Any:
         """
         Get a variable from the kernel language.
         """
         python_magic = self.line_magics["python"]
         return python_magic.env[name]
 
-    def do_execute_direct(self, code, *args, **kwargs):
+    def do_execute_direct(self, code: str, silent: bool = False) -> Any:
         python_magic = self.line_magics["python"]
         return python_magic.eval(code.strip())
 
-    def do_execute_meta(self, code) -> str | None:
+    def do_execute_meta(self, code: str) -> str | None:
         if code == "reset":
             return "RESET"
         elif code == "stop":
@@ -67,7 +59,7 @@ class EvalKernel(MetaKernel):
         else:
             raise Exception("Unknown meta command: '%s'" % code)
 
-    def initialize_debug(self, code) -> str:
+    def initialize_debug(self, code: str) -> str:
         return "highlight: [%s, %s, %s, %s]" % (0, 0, 1, 0)
 
 
@@ -80,9 +72,6 @@ def has_network() -> bool:
     except requests.exceptions.RequestException:
         print("No internet connection available.")
     return False
-
-
-from metakernel._metakernel import MetaKernel
 
 
 def get_log() -> Logger:


### PR DESCRIPTION
## Summary

- Annotate `EvalKernel` methods and clean up imports in `tests/utils.py`
- Add typed `__init__` to `MetaKernelApp` to resolve `no-untyped-call` errors
- Widen `plot_settings` to `dict[str, Any]` to accommodate `int` values (width/height/resolution)
- Widen `self._`, `self.__`, `self.___` to `Any` (they hold arbitrary execution results)
- Add type annotations to `_setup()` in `test_install_magic.py`
- Add typed `__init__` and method signatures to all mock classes in `test_parallel_magic.py`
- Annotate `TestKernel` methods in `test_metakernel.py`