### PR TITLE
Add --display-name option to kernel install subcommand

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,3 +5,37 @@ You can install metakernel through ``pip``:
 
 
 ``pip install metakernel --upgrade``
+
+Installing a kernel
+===================
+
+MetaKernel-based kernels expose an ``install`` subcommand that registers the
+kernel with Jupyter:
+
+.. code-block:: bash
+
+    python -m my_kernel install --user
+
+All flags are forwarded to ``jupyter kernelspec install``.  Common options:
+
+``--user``
+    Install into the current user's Jupyter data directory.
+
+``--sys-prefix``
+    Install into the active Python environment's prefix (useful with conda/venv).
+
+``--prefix <path>``
+    Install into an arbitrary prefix.
+
+``--name <name>``
+    Override the kernel directory name used by Jupyter.
+
+``--display-name <name>``
+    Set the display name shown in the JupyterLab kernel picker.  This is
+    written into the ``display_name`` field of the installed ``kernel.json``
+    and is useful when running multiple installations of the same kernel
+    side-by-side (for example, one per environment):
+
+    .. code-block:: bash
+
+        python -m my_kernel install --user --name my-kernel-dev --display-name "My Kernel (dev)"

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -873,12 +873,27 @@ class MetaKernelApp(IPKernelApp):
 
         class KernelInstallerApp(Application):
             kernel_class = self.kernel_class
+            display_name: str | None = None
 
             def initialize(self, argv: Any = None) -> None:
-                self.argv = argv
+                filtered: list[str] = []
+                args = list(argv or [])
+                i = 0
+                while i < len(args):
+                    if args[i].startswith("--display-name="):
+                        self.display_name = args[i].split("=", 1)[1]
+                    elif args[i] == "--display-name" and i + 1 < len(args):
+                        self.display_name = args[i + 1]
+                        i += 1
+                    else:
+                        filtered.append(args[i])
+                    i += 1
+                self.argv = filtered
 
             def start(self) -> None:
                 kernel_spec = self.kernel_class().kernel_json
+                if self.display_name is not None:
+                    kernel_spec["display_name"] = self.display_name
                 with TemporaryDirectory() as td:
                     dirname = os.path.join(td, kernel_spec["name"])
                     os.mkdir(dirname)

--- a/tests/test_metakernel_app.py
+++ b/tests/test_metakernel_app.py
@@ -125,12 +125,12 @@ class TestMetaKernelAppSubcommands:
         installer = KernelInstallerApp()
         installer.initialize(["--user", "--display-name", "Custom Name"])
 
-        written_spec = None
+        written_spec: dict[str, object] | None = None
         original_dump = __import__("json").dump
 
         def capture_dump(obj: object, f: object, **kwargs: object) -> None:
             nonlocal written_spec
-            written_spec = obj
+            written_spec = obj  # type: ignore[assignment]
             original_dump(obj, f, **kwargs)
 
         with (

--- a/tests/test_metakernel_app.py
+++ b/tests/test_metakernel_app.py
@@ -91,6 +91,57 @@ class TestMetaKernelAppSubcommands:
         installer.initialize(["--user"])
         assert installer.argv == ["--user"]
 
+    def test_install_app_initialize_extracts_display_name_space(self) -> None:
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        installer = KernelInstallerApp()
+        installer.initialize(["--user", "--display-name", "My Kernel"])
+        assert installer.display_name == "My Kernel"
+        assert installer.argv == ["--user"]
+
+    def test_install_app_initialize_extracts_display_name_equals(self) -> None:
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        installer = KernelInstallerApp()
+        installer.initialize(["--display-name=My Kernel", "--user"])
+        assert installer.display_name == "My Kernel"
+        assert installer.argv == ["--user"]
+
+    def test_install_start_applies_display_name(self) -> None:
+        kernel_json = {
+            "argv": ["python", "-m", "test_kernel"],
+            "display_name": "Test Kernel",
+            "language": "test",
+            "name": "test-kernel",
+        }
+        mock_kernel_class = MagicMock()
+        mock_kernel_class.return_value.kernel_json = kernel_json
+        mock_kernel_class.__module__ = "metakernel"
+
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        KernelInstallerApp.kernel_class = mock_kernel_class
+
+        installer = KernelInstallerApp()
+        installer.initialize(["--user", "--display-name", "Custom Name"])
+
+        written_spec = None
+        original_dump = __import__("json").dump
+
+        def capture_dump(obj: object, f: object, **kwargs: object) -> None:
+            nonlocal written_spec
+            written_spec = obj
+            original_dump(obj, f, **kwargs)
+
+        with (
+            patch("subprocess.check_call"),
+            patch("json.dump", side_effect=capture_dump),
+        ):
+            installer.start()
+
+        assert written_spec is not None
+        assert written_spec["display_name"] == "Custom Name"
+
     def test_install_start_calls_kernelspec_install(self) -> None:
         kernel_json = {
             "argv": ["python", "-m", "test_kernel"],


### PR DESCRIPTION
## Summary

- Adds a `--display-name` option to the `install` subcommand of MetaKernel-based kernels
- The value is written into the `display_name` field of the installed `kernel.json`, allowing users to distinguish multiple installations of the same kernel (e.g. per conda environment) in the JupyterLab kernel picker
- The flag is stripped from argv before being forwarded to `jupyter kernelspec install`

## Usage

```bash
python -m my_kernel install --user --name my-kernel-dev --display-name "My Kernel (dev)"
```

## Test plan

- [x] New unit tests cover `--display-name value` and `--display-name=value` argument forms
- [x] New unit test verifies the override is written into `kernel.json`
- [x] Existing tests continue to pass

Closes #200