### PR TITLE
Wait for any output instead of default prompt on startup

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -117,7 +117,7 @@ class REPLWrapper:
             self.child.readline()
 
     def set_prompt(self, prompt_regex: str, prompt_change_cmd: str) -> None:
-        self.child.expect(prompt_regex)
+        self.child.expect([r"[\s\S]+"])
         self.sendline(prompt_change_cmd)
         self.prompt_change_cmd = prompt_change_cmd
 


### PR DESCRIPTION
## Summary

- Fixes startup failure when the user has a custom prompt that doesn't match `prompt_regex`
- Instead of `self.child.expect(prompt_regex)` in `set_prompt` (which times out with custom prompts), wait for any characters to be printed (`[\s\S]+`) before sending the prompt change command
- This is a reimplementation of #286 that fixes the root cause rather than skipping the wait entirely

Closes #286 

## Test plan

- [x] Verify existing tests pass: `just test`
- [x] Manually test with a kernel that uses a custom REPL prompt to confirm no startup timeout