### PR TITLE
Fix shell_magic load failure on Windows by lazy-initializing shell process

### DIFF
--- a/metakernel/magics/shell_magic.py
+++ b/metakernel/magics/shell_magic.py
@@ -15,7 +15,6 @@ class ShellMagic(Magic):
         super().__init__(kernel)
         self.repl: REPLWrapper | None = None
         self.cmd: str | None = None
-        self.start_process()
 
     def line_shell(self, *args: str) -> None:
         """
@@ -49,6 +48,8 @@ class ShellMagic(Magic):
             os.chdir(cwd)
 
     def eval(self, cmd: str, incremental: bool = False) -> str:
+        if self.repl is None:
+            self.start_process()
         assert self.repl is not None
         stream_handler = self.kernel.Print if incremental else None
         return self.repl.run_command(cmd, timeout=None, stream_handler=stream_handler)

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -495,13 +495,17 @@ class _FakeApp(LoggingConfigurable):
 
 
 def _make_kernel_with_parent(extra_args: list[str]) -> MetaKernel:
+    import weakref
+
     ctx = zmq.Context.instance()
     sock = ctx.socket(zmq.PUB)
     parent = _FakeApp()
     parent.extra_args = extra_args  # type: ignore[attr-defined]
-    return MetaKernel(
+    kernel = MetaKernel(
         session=ss.Session(), iopub_socket=sock, log=get_log(), parent=parent
     )
+    weakref.finalize(kernel, sock.close)
+    return kernel
 
 
 class TestConstructorWithExtraArgs:


### PR DESCRIPTION
Closes #247

## Summary

- `ShellMagic.__init__` was eagerly calling `start_process()`, which on Windows immediately tried to spawn a powershell process via pexpect
- On some systems (Windows 7 per the report), the pexpect prompt detection timed out, raising a `pexpect.TIMEOUT` exception
- This propagated through `register_magics()` to `reload_magics()`, which logged a spurious `"Can't load shell_magic.py"` error and left the magic unregistered
- Fix: remove the `start_process()` call from `__init__` and add lazy initialization in `eval()` — the process is now started on first use

## Test plan

- [x] Existing `tests/magics/test_shell_magic.py` tests all pass (verified locally)
- [x] On Windows: confirm `python -m octave_kernel.check` (or any MetaKernel-based kernel check) no longer shows the "Can't load shell_magic.py" error
- [x] `%shell` / `!` commands still work normally when invoked