### PR TITLE
Fix ipywidgets Output context manager not working with MetaKernel

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -165,7 +165,7 @@ class MetaKernel(Kernel):
             def _create_comm_with_kernel(*args: Any, **kwargs: Any) -> Any:
                 c = _base_create_comm(*args, **kwargs)
                 if getattr(c, "kernel", None) is None:
-                    c.kernel = _kernel_ref
+                    c.kernel = _kernel_ref  # type: ignore[attr-defined]
                 return c
 
             comm.create_comm = _create_comm_with_kernel

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -155,6 +155,23 @@ class MetaKernel(Kernel):
         if Widget is not None:
             widgets.register_comm_target()
 
+        # Ensure comm objects created by this kernel have kernel=self set at
+        # construction time. This allows ipywidgets.Output context manager to
+        # reach kernel.get_parent() and correctly set msg_id (issue #217).
+        try:
+            _kernel_ref = self
+            _base_create_comm = comm.create_comm
+
+            def _create_comm_with_kernel(*args: Any, **kwargs: Any) -> Any:
+                c = _base_create_comm(*args, **kwargs)
+                if getattr(c, "kernel", None) is None:
+                    c.kernel = _kernel_ref
+                return c
+
+            comm.create_comm = _create_comm_with_kernel
+        except Exception:
+            pass
+
         self.hist_file = get_history_file(self)
         self.parser = Parser(
             self.identifier_regex,

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -857,6 +857,29 @@ class TestClearOutput:
         )
 
 
+class TestIpywidgetsOutputContextManager:
+    """Regression tests for issue #217: ipywidgets.Output context manager with MetaKernel."""
+
+    def test_output_widget_context_manager_sets_msg_id(self) -> None:
+        """ipywidgets.Output context manager sets msg_id when used with MetaKernel."""
+        ipywidgets = pytest.importorskip("ipywidgets")
+        kernel = get_kernel()
+        # Simulate an execute_request by setting a parent message
+        parent_msg = {
+            "header": {"msg_id": "test-msg-123", "msg_type": "execute_request"},
+            "content": {},
+        }
+        kernel.set_parent([], parent_msg, channel="shell")
+
+        output = ipywidgets.Output()
+        assert output.msg_id == "", "msg_id should be empty before entering context"
+        with output:
+            assert output.msg_id == "test-msg-123", (
+                "msg_id should be set to the parent execute_request msg_id inside context"
+            )
+        assert output.msg_id == "", "msg_id should be cleared after exiting context"
+
+
 def teardown() -> None:
     if os.path.exists("TEST.txt"):
         os.remove("TEST.txt")

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -869,7 +869,7 @@ class TestIpywidgetsOutputContextManager:
             "header": {"msg_id": "test-msg-123", "msg_type": "execute_request"},
             "content": {},
         }
-        kernel.set_parent([], parent_msg, channel="shell")
+        kernel.set_parent([], parent_msg, channel="shell")  # type: ignore[no-untyped-call]
 
         output = ipywidgets.Output()
         assert output.msg_id == "", "msg_id should be empty before entering context"


### PR DESCRIPTION
## Summary

- `ipywidgets.Output`'s `with output:` context manager failed to route output to the widget when used with MetaKernel because `get_ipython()` returned `None` and `comm.kernel` was `None` at construction time
- Fixed by overriding `comm.create_comm` in `MetaKernel.__init__` to pre-set `kernel=self` on newly created comms, enabling the `comm.kernel` fallback path in `Output.__enter__` to call `kernel.get_parent()` and set `msg_id` correctly
- Added a regression test that simulates an execute request and verifies `msg_id` is set/cleared correctly when entering/exiting the context manager

Closes #217

## Test plan

- [x] `just test` passes (458 passed, 11 skipped)
- [x] New test `TestIpywidgetsOutputContextManager::test_output_widget_context_manager_sets_msg_id` covers the regression