### PR TITLE
Add %lsmagic -v for magic load debugging

### DIFF
--- a/docs/new_magic.md
+++ b/docs/new_magic.md
@@ -84,6 +84,28 @@ my_kernel/
 
 No extra registration step is required — the `register_magics(kernel)` function in each file is called automatically.
 
+## Debugging magic loading
+
+If a magic is not appearing as expected, use `%lsmagic -v` to see which directories MetaKernel searched and whether any files failed to load:
+
+```
+%lsmagic -v
+```
+
+The output includes:
+
+- **Magic search paths** — the directories that were scanned for `*_magic.py` files. For a bundled kernel magic, the first entry should be the `magics/` subdirectory of your kernel package. If your magic file is not in one of these directories, it will never be found.
+- **Load errors** — any exceptions raised while importing a magic file or calling its `register_magics` function. The error message points directly to the file and the cause.
+
+If your magic is missing after a regular (non-editable) install, verify that the `magics/` directory is included in your package. With hatchling add it explicitly if needed:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = ["my_kernel"]
+```
+
+After fixing the file placement, restart the kernel and run `%lsmagic -v` again to confirm the path appears and no errors are reported.
+
 ## Writing a cell magic
 
 A cell magic receives the rest of the cell as a body via `self.code`. Set `self.evaluate = False` if you do not want the kernel to evaluate the cell body as normal code after the magic runs.

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -184,6 +184,8 @@ class MetaKernel(Kernel):
             self.shell_handlers[msg_type] = getattr(self.comm_manager, msg_type)
         self._display_formatter = DisplayFormatter()  # pass kwargs?
         self.env: dict[str, Any] = {}
+        self.magic_search_paths: list[str] = []
+        self.magic_load_errors: list[tuple[str, str]] = []
         self.reload_magics()
         # provide a way to get the current instance
         self.set_variable("kernel", self)
@@ -759,6 +761,7 @@ class MetaKernel(Kernel):
         """Reload all of the line and cell magics."""
         self.line_magics: dict[str, Any] = {}
         self.cell_magics: dict[str, Any] = {}
+        self.magic_load_errors = []
 
         # get base magic files and those relative to the current class
         # directory
@@ -779,6 +782,7 @@ class MetaKernel(Kernel):
             local_magics_dir,
             os.path.join(os.path.dirname(os.path.abspath(__file__)), "magics"),
         ]
+        self.magic_search_paths = list(paths)
         for magic_dir in paths:
             sys.path.append(magic_dir)
             magic_files.extend(glob.glob(os.path.join(magic_dir, "*.py")))
@@ -793,6 +797,7 @@ class MetaKernel(Kernel):
                 module.register_magics(self)
             except Exception as e:
                 self.log.error(f"Can't load '{magic}': error: {e}")
+                self.magic_load_errors.append((magic, str(e)))
 
     def register_magics(self, magic_klass: type[Magic]) -> None:
         """Register magics for a given magic_klass."""

--- a/metakernel/magics/README.md
+++ b/metakernel/magics/README.md
@@ -267,14 +267,22 @@ Options:
 
 ## `%lsmagic`
 
-%lsmagic - list the current line and cell magics
+%lsmagic [-v] - list the current line and cell magics
 
 This line magic will list all of the available cell and line
 magics installed in the system and in your personal magic
 folder.
 
+Use -v/--verbose to also show the directories that were searched
+and any errors that occurred while loading magic files.
+
 Example:
     %lsmagic
+    %lsmagic -v
+
+Options:
+--------
+-v --verbose   Also show magic search paths and any load errors. [default: False]
 
 ## `%macro`
 

--- a/metakernel/magics/lsmagic_magic.py
+++ b/metakernel/magics/lsmagic_magic.py
@@ -1,20 +1,31 @@
 # Copyright (c) Metakernel Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from metakernel import Magic, MetaKernel
+from metakernel import Magic, MetaKernel, option
 
 
 class LSMagicMagic(Magic):
-    def line_lsmagic(self) -> None:
+    @option(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Also show magic search paths and any load errors.",
+    )
+    def line_lsmagic(self, verbose: bool = False) -> None:
         """
-        %lsmagic - list the current line and cell magics
+        %lsmagic [-v] - list the current line and cell magics
 
         This line magic will list all of the available cell and line
         magics installed in the system and in your personal magic
         folder.
 
+        Use -v/--verbose to also show the directories that were searched
+        and any errors that occurred while loading magic files.
+
         Example:
             %lsmagic
+            %lsmagic -v
         """
         line_magics = self.kernel.line_magics.keys()
         cell_magics = self.kernel.cell_magics.keys()
@@ -27,6 +38,20 @@ class LSMagicMagic(Magic):
             "Available cell magics:",
             "  ".join(sorted([(mp + mp + cm) for cm in cell_magics])),
         ]
+
+        if verbose:
+            search_paths = getattr(self.kernel, "magic_search_paths", [])
+            load_errors = getattr(self.kernel, "magic_load_errors", [])
+            out += ["", "Magic search paths:"]
+            for path in search_paths:
+                out.append(f"  {path}")
+            if load_errors:
+                out += ["", "Load errors:"]
+                for path, error in load_errors:
+                    out.append(f"  {path}: {error}")
+            else:
+                out += ["", "No load errors."]
+
         self.kernel.Print("\n".join(out))
 
 

--- a/tests/magics/test_lsmagic_magic.py
+++ b/tests/magics/test_lsmagic_magic.py
@@ -1,4 +1,7 @@
 import asyncio
+import os
+import tempfile
+import unittest.mock
 
 from tests.utils import get_kernel, get_log_text
 
@@ -10,3 +13,35 @@ def test_lsmagic_magic() -> None:
 
     for item in "%cd %connect_info %download %edit %help %html %install_magic %javascript %kernel %kx %latex %load %lsmagic %magic %parallel %plot %pmap %px %python %reload_magics %restart %run %shell %macro %%debug %%file %%help %%html %%javascript %%kx %%latex %%processing %%px %%python %%shell %%show %%macro %%time".split():
         assert item in text, "lsmagic didn't list '%s'" % item
+
+
+def test_lsmagic_verbose() -> None:
+    kernel = get_kernel()
+    asyncio.run(kernel.do_execute("%lsmagic -v"))
+    text = get_log_text(kernel)
+
+    assert "Magic search paths:" in text
+    assert "No load errors." in text
+
+
+def test_lsmagic_verbose_with_load_error() -> None:
+    with tempfile.TemporaryDirectory() as local_magics_dir:
+        broken_magic = os.path.join(local_magics_dir, "broken_magic.py")
+        with open(broken_magic, "w") as f:
+            f.write("this is not valid python )(")
+
+        with unittest.mock.patch(
+            "metakernel._metakernel.get_local_magics_dir",
+            return_value=local_magics_dir,
+        ):
+            kernel = get_kernel()
+
+        assert local_magics_dir in kernel.magic_search_paths
+        assert any(broken_magic in path for path, _ in kernel.magic_load_errors)
+
+        asyncio.run(kernel.do_execute("%lsmagic -v"))
+        text = get_log_text(kernel)
+
+    assert local_magics_dir in text
+    assert "Load errors:" in text
+    assert "broken_magic.py" in text


### PR DESCRIPTION
Closes #193.

## Summary

- `reload_magics()` now records `magic_search_paths` and `magic_load_errors` on the kernel after each load cycle
- `%lsmagic` gains a `-v`/`--verbose` flag that prints the search paths and any load errors (or "No load errors.")
- Adds a "Debugging magic loading" section to `docs/new_magic.md` explaining how to use `%lsmagic -v` and how to diagnose the editable-vs-regular-install issue described in the issue

## Test plan

- [ ] `%lsmagic` output unchanged without `-v`
- [ ] `%lsmagic -v` shows search paths and "No load errors." on a clean kernel
- [ ] A broken magic file produces an entry under "Load errors:" when using `-v`
- [ ] All existing tests pass (`just test`)