### PR TITLE
Include magics README in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: mdformat
         verbose: true
-        exclude: "metakernel/magics/README\\.md|docs/index\\.md"
+        exclude: "metakernel/magics/README\\.md|docs/index\\.md|docs/magics\\.md"
   
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2

--- a/docs/magics.md
+++ b/docs/magics.md
@@ -1,0 +1,1 @@
+--8<-- "metakernel/magics/README.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,4 +42,5 @@ nav:
   - Example Notebook: MetaKernel Echo Demo.ipynb
   - Creating a Kernel: new_kernel.md
   - Creating a Magic: new_magic.md
+  - Magics Reference: magics.md
   - API Reference: api.md


### PR DESCRIPTION
Adds a Magics Reference page to the MkDocs site by including `metakernel/magics/README.md` via the snippets plugin. Also excludes `docs/magics.md` from mdformat to prevent it from escaping the snippet syntax.