### PR TITLE
Add DisplayData() for raw MIME bundle display

### DIFF
--- a/docs/new_kernel.md
+++ b/docs/new_kernel.md
@@ -87,6 +87,51 @@ Create `data_kernelspec/share/jupyter/kernels/my_kernel/kernel.json`:
 
 Optional keys include `"codemirror_mode"`, `"env"`, and `"interrupt_mode"`. See the [Jupyter kernel specification](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for the full list.
 
+## Rich display output
+
+MetaKernel provides two complementary display paths depending on whether your kernel produces Python objects or raw MIME data.
+
+### Python objects
+
+Call `self.Display(obj)` from within `do_execute_direct` (or from a magic). MetaKernel passes the object through IPython's display formatter, which invokes `_repr_html_`, `_repr_svg_`, `_repr_png_`, and similar methods automatically:
+
+```python
+def do_execute_direct(self, code):
+    from IPython.display import HTML
+    return HTML("<b>result</b>")
+```
+
+You can also return the object directly from `do_execute_direct` and MetaKernel will format and publish it as an `execute_result`.
+
+### Raw MIME bundles (non-Python kernels)
+
+If your kernel generates display data natively — for example a C++ kernel that produces SVG or HTML — use `self.DisplayData(data)` to send a raw MIME bundle directly without going through IPython's formatter:
+
+```python
+def do_execute_direct(self, code):
+    # Call your language runtime and get MIME data back
+    mime_bundle = evaluate(code)  # e.g. {'text/html': '<b>result</b>', 'text/plain': 'result'}
+    self.DisplayData(mime_bundle)
+```
+
+`DisplayData` accepts an optional `metadata` dict keyed by MIME type:
+
+```python
+self.DisplayData(
+    {"image/svg+xml": svg_string, "text/plain": "[SVG image]"},
+    metadata={"image/svg+xml": {"isolated": True}},
+)
+```
+
+You can also return a MIME bundle dict directly from `do_execute_direct`. MetaKernel detects dicts whose keys are all MIME types and publishes them as `execute_result` without formatting:
+
+```python
+def do_execute_direct(self, code):
+    return {"text/html": "<b>result</b>", "text/plain": "result"}
+```
+
+As a convenience, `self.Display()` also accepts a raw MIME bundle dict and routes it to `DisplayData` automatically, so you can pass MIME data through the same call site as Python objects.
+
 ## Adding custom magics
 
 Place magic files in a `magics/` subpackage alongside your kernel module. Each file should be named `{name}_magic.py` and define a class that inherits from `Magic`. Line magics are methods named `line_{name}` and cell magics are `cell_{name}`:

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -34,6 +34,21 @@ if TYPE_CHECKING:
 
 warnings.filterwarnings("ignore", module="IPython.html.widgets")
 
+
+def _is_mime_bundle(obj: Any) -> bool:
+    """Return True if *obj* looks like a raw MIME bundle dict.
+
+    A MIME bundle is a non-empty dict whose keys are all MIME-type strings
+    (they all contain a ``/`` character), e.g.
+    ``{'text/html': '<b>hi</b>', 'text/plain': 'hi'}``.
+    """
+    return (
+        isinstance(obj, dict)
+        and bool(obj)
+        and all(isinstance(k, str) and "/" in k for k in obj)
+    )
+
+
 try:
     import ipywidgets as widgets  #  type:ignore[import-untyped]
     from ipywidgets.widgets.widget import Widget  #  type:ignore[import-untyped]
@@ -470,6 +485,14 @@ class MetaKernel(Kernel):
                 self.kernel_resp.update(content)
                 if not silent:
                     self.send_response(self.iopub_socket, "error", content)
+            elif _is_mime_bundle(retval):
+                if not silent:
+                    content = {
+                        "execution_count": self.execution_count,
+                        "data": retval,
+                        "metadata": {},
+                    }
+                    self.send_response(self.iopub_socket, "execute_result", content)
             else:
                 try:
                     data = self._display_formatter.format(retval)  # type:ignore[no-untyped-call]
@@ -649,10 +672,39 @@ class MetaKernel(Kernel):
         """Clear the output of the kernel."""
         self.send_response(self.iopub_socket, "clear_output", {"wait": wait})
 
+    def DisplayData(
+        self, data: dict[str, Any], metadata: dict[str, Any] | None = None
+    ) -> None:
+        """Display a raw MIME bundle directly without going through IPython's formatter.
+
+        Use this when your kernel produces display data in MIME format directly,
+        rather than Python objects with ``_repr_*_`` methods. This is the recommended
+        approach for non-Python kernels (e.g. C++, Julia) that generate rich output.
+
+        Args:
+            data: A dict mapping MIME types to content.
+                  Example: ``{'text/html': '<b>hello</b>', 'text/plain': 'hello'}``
+            metadata: Optional dict of per-MIME-type metadata.
+
+        Example::
+
+            kernel.DisplayData(
+                {'text/html': '<b>Rich output</b>', 'text/plain': 'Rich output'},
+                metadata={'text/html': {'isolated': True}},
+            )
+        """
+        self.log.debug("DisplayData: %s", list(data.keys()))
+        content = {"data": data, "metadata": metadata or {}}
+        self.send_response(self.iopub_socket, "display_data", content)
+
     def Display(self, *objects: Any, **kwargs: Any) -> None:
         """Display one or more objects using rich display.
 
         Supports a `clear_output` keyword argument that clears the output before displaying.
+
+        If an object is a dict whose keys are all MIME types (strings containing ``/``),
+        it is treated as a raw MIME bundle and sent directly — equivalent to calling
+        :meth:`DisplayData`.
 
         See https://ipython.readthedocs.io/en/stable/config/integrating.html?highlight=display#rich-display
         """
@@ -672,6 +724,9 @@ class MetaKernel(Kernel):
                 }
                 content = {"data": data, "metadata": {}}
                 self.send_response(self.iopub_socket, "display_data", content)
+            elif _is_mime_bundle(item):
+                self.log.debug("Display raw MIME bundle")
+                self.DisplayData(item)
             else:
                 self.log.debug("Display Data")
                 try:

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -880,6 +880,68 @@ class TestIpywidgetsOutputContextManager:
         assert output.msg_id == "", "msg_id should be cleared after exiting context"
 
 
+class TestDisplayData:
+    """Tests for raw MIME bundle display (issue #211)."""
+
+    MIME_BUNDLE = {"text/html": "<b>hello</b>", "text/plain": "hello"}
+
+    def test_display_data_sends_display_data_message(self) -> None:
+        """DisplayData() sends a display_data response with the given MIME bundle."""
+        kernel = get_kernel()
+        with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+            kernel.DisplayData(self.MIME_BUNDLE)
+        mock_send.assert_called_once_with(
+            kernel.iopub_socket,
+            "display_data",
+            {"data": self.MIME_BUNDLE, "metadata": {}},
+        )
+
+    def test_display_data_passes_metadata(self) -> None:
+        """DisplayData() forwards the metadata dict."""
+        kernel = get_kernel()
+        meta = {"text/html": {"isolated": True}}
+        with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+            kernel.DisplayData(self.MIME_BUNDLE, metadata=meta)
+        mock_send.assert_called_once_with(
+            kernel.iopub_socket,
+            "display_data",
+            {"data": self.MIME_BUNDLE, "metadata": meta},
+        )
+
+    def test_display_routes_mime_bundle_directly(self) -> None:
+        """Display() with a raw MIME bundle dict calls DisplayData, not the formatter."""
+        kernel = get_kernel()
+        with unittest.mock.patch.object(kernel, "DisplayData") as mock_dd:
+            kernel.Display(self.MIME_BUNDLE)
+        mock_dd.assert_called_once_with(self.MIME_BUNDLE)
+
+    def test_display_does_not_treat_plain_dict_as_mime_bundle(self) -> None:
+        """Display() with a plain dict (no '/' in keys) uses the formatter, not DisplayData."""
+        kernel = get_kernel()
+        plain_dict = {"key": "value"}
+        with unittest.mock.patch.object(kernel, "DisplayData") as mock_dd:
+            kernel.Display(plain_dict)
+        mock_dd.assert_not_called()
+
+    def test_post_execute_mime_bundle_sends_execute_result(self) -> None:
+        """post_execute with a MIME bundle return value sends execute_result directly."""
+        kernel = get_kernel(EvalKernel)
+        with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+            asyncio.run(kernel.post_execute(self.MIME_BUNDLE, "code", silent=False))
+        mock_send.assert_called_once()
+        args = mock_send.call_args
+        assert args[0][1] == "execute_result"
+        assert args[0][2]["data"] == self.MIME_BUNDLE
+        assert args[0][2]["metadata"] == {}
+
+    def test_post_execute_mime_bundle_silent_does_not_send(self) -> None:
+        """post_execute with a MIME bundle and silent=True sends no response."""
+        kernel = get_kernel(EvalKernel)
+        with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+            asyncio.run(kernel.post_execute(self.MIME_BUNDLE, "code", silent=True))
+        mock_send.assert_not_called()
+
+
 def teardown() -> None:
     if os.path.exists("TEST.txt"):
         os.remove("TEST.txt")


### PR DESCRIPTION
## Summary

Closes #211

- Adds `MetaKernel.DisplayData(data, metadata=None)` — a new public method for kernels to send raw MIME bundles (e.g. `{'text/html': '...', 'text/plain': '...'}`) directly as `display_data` messages, bypassing IPython's object formatter. This is the recommended path for non-Python kernels (C++, Julia, etc.) that generate display data natively.
- Updates `Display()` to auto-detect and route raw MIME bundle dicts to `DisplayData`, so existing call sites work without changes.
- Updates `post_execute()` so returning a MIME bundle dict from `do_execute_direct` publishes it as `execute_result` without going through the formatter.
- Adds 6 unit tests covering the new display paths.
- Documents the rich display API in `docs/new_kernel.md` under a new "Rich display output" section.

## Test plan

- [x] `just test tests/test_metakernel.py::TestDisplayData` — all 6 new tests pass
- [x] `just test` — full suite passes (466 passed, 11 skipped)
- [ ] `just docs` — documentation builds without errors