### PR TITLE
Fix prompt_change_cmd storing unformatted template

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -91,12 +91,11 @@ class REPLWrapper:
         if prompt_change_cmd is None:
             self.prompt_regex = prompt_regex
         else:
-            self.set_prompt(
-                prompt_regex,
-                prompt_change_cmd.format(new_prompt_regex, continuation_prompt_regex),
+            formatted_prompt_change_cmd = prompt_change_cmd.format(
+                new_prompt_regex, continuation_prompt_regex
             )
+            self.set_prompt(prompt_regex, formatted_prompt_change_cmd)
             self.prompt_regex = new_prompt_regex
-            self.prompt_change_cmd = prompt_change_cmd
         self.continuation_prompt_regex = continuation_prompt_regex
         self.stdin_prompt_regex = stdin_prompt_regex
 

--- a/tests/test_replwrap_init.py
+++ b/tests/test_replwrap_init.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from metakernel import pexpect as mk_pexpect
-from metakernel.replwrap import PEXPECT_PROMPT, REPLWrapper
+from metakernel.replwrap import PEXPECT_CONTINUATION_PROMPT, PEXPECT_PROMPT, REPLWrapper
 
 
 def _make_child(echo: bool = False) -> MagicMock:
@@ -87,9 +87,9 @@ class TestREPLWrapperInit:
             with patch.object(REPLWrapper, "set_prompt") as mock_set:
                 with patch("atexit.register"):
                     wrapper = REPLWrapper(mock_child, r"[$#]", "PS1={0!r} PS2={1!r}")
-        mock_set.assert_called_once()
+        formatted = f"PS1={PEXPECT_PROMPT!r} PS2={PEXPECT_CONTINUATION_PROMPT!r}"
+        mock_set.assert_called_once_with(r"[$#]", formatted)
         assert wrapper.prompt_regex == PEXPECT_PROMPT
-        assert wrapper.prompt_change_cmd == "PS1={0!r} PS2={1!r}"
 
     def test_extra_init_cmd_runs_command(self) -> None:
         """When extra_init_cmd is given, run_command is called with it."""


### PR DESCRIPTION
## Summary
- Fix `REPLWrapper.__init__` overwriting the formatted `prompt_change_cmd` (set by `set_prompt()`) with the raw template containing `{0}`/`{1}` placeholders
- This caused `octave_kernel`'s `_startup()` to send literal placeholders as PS1/PS2 to Octave, so prompts never matched `PEXPECT_PROMPT` and the kernel hung indefinitely
- Regression introduced in #312

Closes #359

## Test plan
- [x] All existing tests pass (466 passed, 11 skipped)
- [x] Updated `test_prompt_change_cmd_not_none_calls_set_prompt` to verify the formatted value is passed to `set_prompt`
- [x] Manual verification with `octave_kernel` + Octave 11