### PR TITLE
Fix %%python display() routing to wrong kernel

### DIFF
--- a/metakernel/magics/python_magic.py
+++ b/metakernel/magics/python_magic.py
@@ -74,7 +74,12 @@ class PythonMagic(Magic):
     def eval(self, code: str) -> Any:
         import IPython.display
 
+        import metakernel
         import metakernel.display
+
+        # Ensure the current kernel is the active one so that display() calls
+        # inside %%python route to this kernel's output, not a stale instance.
+        metakernel.MetaKernel.meta_kernel = self.kernel
 
         # monkey patch IPython.display.display
         # to redirect notebook display calls to kernel display

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -152,3 +152,57 @@ def test_python_magic_html_display() -> None:
     display_msgs3 = [c for msg_type, c in sent3 if msg_type == "display_data"]
     assert display_msgs3, "expected a display_data message from plan()"
     assert display_msgs3[0]["data"]["text/html"] == "<b>plan</b>"
+
+
+def test_display_routes_to_parent_kernel() -> None:
+    """display() calls after %%python should route to the kernel that ran it.
+
+    After %%python executes on a kernel, the monkey-patched IPython.display.display
+    must send output to that kernel (the "parent"), not to a stale instance from a
+    previous %%python call on a different kernel.
+    """
+    import IPython.display
+
+    kernel_a = get_kernel()
+    kernel_b = get_kernel()
+
+    # Run %%python on kernel_a, which sets meta_kernel = kernel_a and patches
+    # IPython.display.display globally.
+    with capture_send_messages(kernel_a) as sent_a:
+        asyncio.run(
+            kernel_a.do_execute(
+                "%%python\nfrom IPython.display import HTML, display",
+                False,
+            )
+        )
+
+    from IPython.display import HTML
+
+    # The monkey-patched display should now route to kernel_a.
+    with capture_send_messages(kernel_a) as sent_a2:
+        IPython.display.display(HTML("<b>from a</b>"))
+    display_a = [c for msg_type, c in sent_a2 if msg_type == "display_data"]
+    assert display_a, "expected display_data routed to kernel_a after its %%python"
+    assert display_a[0]["data"]["text/html"] == "<b>from a</b>"
+
+    # Now run %%python on kernel_b — meta_kernel should switch to kernel_b.
+    with capture_send_messages(kernel_b):
+        asyncio.run(
+            kernel_b.do_execute(
+                "%%python\nfrom IPython.display import HTML, display",
+                False,
+            )
+        )
+
+    # The monkey-patched display should now route to kernel_b, not kernel_a.
+    with (
+        capture_send_messages(kernel_a) as stale_a,
+        capture_send_messages(kernel_b) as sent_b2,
+    ):
+        IPython.display.display(HTML("<b>from b</b>"))
+    assert not [c for msg_type, c in stale_a if msg_type == "display_data"], (
+        "display_data must not route to kernel_a after kernel_b ran %%python"
+    )
+    display_b = [c for msg_type, c in sent_b2 if msg_type == "display_data"]
+    assert display_b, "expected display_data routed to kernel_b"
+    assert display_b[0]["data"]["text/html"] == "<b>from b</b>"

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -1,7 +1,7 @@
 import asyncio
 import textwrap
 
-from tests.utils import clear_log_text, get_kernel, get_log_text
+from tests.utils import capture_send_messages, clear_log_text, get_kernel, get_log_text
 
 
 def test_python_magic() -> None:
@@ -97,3 +97,58 @@ def test_python_magic5() -> None:
     asyncio.run(kernel.do_execute("%python print('hello')"))
 
     assert "hello" in get_log_text(kernel)
+
+
+def test_python_magic_html_display() -> None:
+    """%%python cell should display HTML objects as text/html (issue #187)."""
+    kernel = get_kernel()
+
+    # Returning an HTML object as the last expression should yield text/html
+    with capture_send_messages(kernel) as sent:
+        asyncio.run(
+            kernel.do_execute(
+                "%%python\nfrom IPython.display import HTML\nHTML('<b>hello</b>')",
+                False,
+            )
+        )
+    result_msgs = [c for msg_type, c in sent if msg_type == "execute_result"]
+    assert result_msgs, "expected an execute_result message"
+    assert "text/html" in result_msgs[0]["data"], (
+        "expected text/html in execute_result data"
+    )
+    assert result_msgs[0]["data"]["text/html"] == "<b>hello</b>"
+
+    # Calling display(HTML(...)) explicitly should emit display_data with text/html
+    kernel2 = get_kernel()
+    with capture_send_messages(kernel2) as sent2:
+        asyncio.run(
+            kernel2.do_execute(
+                textwrap.dedent("""\
+                %%python
+                from IPython.display import HTML, display
+                display(HTML('<i>world</i>'))"""),
+                False,
+            )
+        )
+    display_msgs = [c for msg_type, c in sent2 if msg_type == "display_data"]
+    assert display_msgs, "expected a display_data message"
+    assert "text/html" in display_msgs[0]["data"], "expected text/html in display_data"
+    assert display_msgs[0]["data"]["text/html"] == "<i>world</i>"
+
+    # A function that calls display(HTML(...)) internally should also work
+    kernel3 = get_kernel()
+    with capture_send_messages(kernel3) as sent3:
+        asyncio.run(
+            kernel3.do_execute(
+                textwrap.dedent("""\
+                %%python
+                from IPython.display import HTML, display
+                def plan():
+                    display(HTML('<b>plan</b>'))
+                plan()"""),
+                False,
+            )
+        )
+    display_msgs3 = [c for msg_type, c in sent3 if msg_type == "display_data"]
+    assert display_msgs3, "expected a display_data message from plan()"
+    assert display_msgs3[0]["data"]["text/html"] == "<b>plan</b>"

--- a/tests/magics/test_python_magic.py
+++ b/tests/magics/test_python_magic.py
@@ -168,7 +168,7 @@ def test_display_routes_to_parent_kernel() -> None:
 
     # Run %%python on kernel_a, which sets meta_kernel = kernel_a and patches
     # IPython.display.display globally.
-    with capture_send_messages(kernel_a) as sent_a:
+    with capture_send_messages(kernel_a):
         asyncio.run(
             kernel_a.do_execute(
                 "%%python\nfrom IPython.display import HTML, display",
@@ -180,7 +180,7 @@ def test_display_routes_to_parent_kernel() -> None:
 
     # The monkey-patched display should now route to kernel_a.
     with capture_send_messages(kernel_a) as sent_a2:
-        IPython.display.display(HTML("<b>from a</b>"))
+        IPython.display.display(HTML("<b>from a</b>"))  # type: ignore[no-untyped-call]
     display_a = [c for msg_type, c in sent_a2 if msg_type == "display_data"]
     assert display_a, "expected display_data routed to kernel_a after its %%python"
     assert display_a[0]["data"]["text/html"] == "<b>from a</b>"
@@ -199,7 +199,7 @@ def test_display_routes_to_parent_kernel() -> None:
         capture_send_messages(kernel_a) as stale_a,
         capture_send_messages(kernel_b) as sent_b2,
     ):
-        IPython.display.display(HTML("<b>from b</b>"))
+        IPython.display.display(HTML("<b>from b</b>"))  # type: ignore[no-untyped-call]
     assert not [c for msg_type, c in stale_a if msg_type == "display_data"], (
         "display_data must not route to kernel_a after kernel_b ran %%python"
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from io import StringIO
 from logging import Logger, StreamHandler
 from typing import Any, TypeVar, overload
@@ -12,6 +14,7 @@ from metakernel import MetaKernel
 
 __all__ = [
     "EvalKernel",
+    "capture_send_messages",
     "clear_log_text",
     "get_kernel",
     "get_log",
@@ -119,6 +122,30 @@ def clear_log_text(obj: Any) -> None:
     assert isinstance(handler, StreamHandler)
     handler.stream.truncate(0)
     handler.stream.seek(0)
+
+
+@contextmanager
+def capture_send_messages(
+    kernel: MetaKernel,
+) -> Iterator[list[tuple[str, dict[str, Any]]]]:
+    """Context manager that captures messages sent via kernel.send_response.
+
+    Yields a list of (msg_type, content) tuples accumulated during the block.
+    """
+    sent: list[tuple[str, dict[str, Any]]] = []
+    original = kernel.send_response
+
+    def _capture(
+        socket: Any, msg_type: str, content: dict[str, Any], **kwargs: Any
+    ) -> Any:
+        sent.append((msg_type, content))
+        return original(socket, msg_type, content, **kwargs)
+
+    kernel.send_response = _capture  # type: ignore[method-assign]
+    try:
+        yield sent
+    finally:
+        kernel.send_response = original  # type: ignore[method-assign]
 
 
 def get_log_text(obj: Any) -> str:


### PR DESCRIPTION
Closes #187.

## Summary

- `MetaKernel.meta_kernel` was only assigned once — when the very first kernel instance was created. Any subsequent `display()` call inside a `%%python` cell silently routed to that stale kernel instance rather than the currently-executing one, causing rich display output (`HTML`, `Markdown`, etc.) to be dropped.
- Fix: update `MetaKernel.meta_kernel = self.kernel` at the top of `PythonMagic.eval()` so `display()` always routes to the active kernel.

## Test plan

- Added `capture_send_messages()` context manager to `tests/utils.py` for intercepting `send_response` calls in tests.
- Added `test_python_magic_html_display` covering:
  - [x] `HTML(...)` as the last expression in `%%python` → `execute_result` with `text/html`
  - [x] `display(HTML(...))` explicit call → `display_data` with `text/html`
  - [x] A user-defined function calling `display(HTML(...))` internally → `display_data` with `text/html` (the pattern from the issue)