### PR TITLE
Fix execute_reply reporting 'ok' status when do_execute_direct raises

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -432,9 +432,12 @@ class MetaKernel(Kernel):
                 if code.startswith("~~META~~:"):
                     retval = self.do_execute_meta(code[9:].strip())
                 else:
-                    retval = self.do_execute_direct(code)
-                    if inspect.isawaitable(retval):
-                        retval = await retval
+                    try:
+                        retval = self.do_execute_direct(code)
+                        if inspect.isawaitable(retval):
+                            retval = await retval
+                    except Exception as e:
+                        retval = ExceptionWrapper(type(e).__name__, str(e), [])
             # Post-process magics:
             for magic in reversed(stack):
                 retval = magic.post_process(retval)
@@ -442,9 +445,12 @@ class MetaKernel(Kernel):
             if code.startswith("~~META~~:"):
                 retval = self.do_execute_meta(code[9:].strip())
             else:
-                retval = self.do_execute_direct(code)
-                if inspect.isawaitable(retval):
-                    retval = await retval
+                try:
+                    retval = self.do_execute_direct(code)
+                    if inspect.isawaitable(retval):
+                        retval = await retval
+                except Exception as e:
+                    retval = ExceptionWrapper(type(e).__name__, str(e), [])
 
         await self.post_execute(retval, code, silent)
 

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -670,6 +670,17 @@ class TestDoExecute:
                     os.remove(fname)
         mock_exec.assert_not_called()
 
+    def test_exception_from_do_execute_direct_sets_error_status(self) -> None:
+        """When do_execute_direct raises an exception, execute_reply status is 'error' (issue #175)."""
+        kernel = get_kernel(EvalKernel)
+        with unittest.mock.patch.object(
+            kernel, "do_execute_direct", side_effect=RuntimeError("kernel blew up")
+        ):
+            resp = asyncio.run(kernel.do_execute("some_code", False))
+        assert resp["status"] == "error"
+        assert resp["ename"] == "RuntimeError"
+        assert resp["evalue"] == "kernel blew up"
+
 
 class TestDoShutdown:
     def test_no_hist_file_skips_file_write(self) -> None:


### PR DESCRIPTION
Closes #175.

## Summary

- When `do_execute_direct` raises an exception, `do_execute` previously had no try/except around it, so the exception propagated uncaught and `kernel_resp["status"]` was never updated from `'ok'` to `'error'`
- Wrap both `do_execute_direct` call sites in `do_execute` with `try/except Exception`, converting any raised exception into an `ExceptionWrapper` so that `post_execute` sets `status: 'error'` in the `execute_reply` as required by the Jupyter messaging spec

## Test plan

- [ ] Added `test_exception_from_do_execute_direct_sets_error_status` to `TestDoExecute` — patches `do_execute_direct` to raise `RuntimeError` and asserts the reply has `status: 'error'` with matching `ename`/`evalue`
- [ ] All existing tests continue to pass