### PR TITLE
Add encoding parameter to REPLWrapper to fix startup hang on Windows

### DIFF
--- a/docs/new_kernel.md
+++ b/docs/new_kernel.md
@@ -290,3 +290,26 @@ jupyter console --log-level=debug --kernel=octave
 ```
 
 Replace `octave` with the name of your kernel (the directory name under `share/jupyter/kernels/`). Debug output includes the raw ZMQ messages exchanged between the client and kernel, which is useful for diagnosing protocol-level issues.
+
+## Troubleshooting
+
+### Kernel hangs at startup on Windows (encoding mismatch)
+
+If your kernel uses `ProcessMetaKernel` / `REPLWrapper` and hangs indefinitely at startup on Windows — with `pexpect` timing out while waiting for the initial prompt — the cause is often an encoding mismatch. `REPLWrapper` defaults to `encoding="utf-8"`, but many Windows programs (including gnuplot) write their startup output in the system code page (e.g. `cp1252`). When pexpect can't decode the bytes it receives it never matches the prompt pattern, so the kernel never finishes initialising.
+
+Pass the correct encoding when constructing `REPLWrapper`:
+
+```python
+from metakernel.replwrap import REPLWrapper
+
+repl = REPLWrapper("gnuplot", r"gnuplot>", None, encoding="cp1252")
+```
+
+To find the encoding your program uses, run it in a terminal and check what Python reports:
+
+```python
+import locale
+print(locale.getpreferredencoding())
+```
+
+Or start with `encoding="cp1252"` on Western-European Windows locales and `encoding="utf-8"` everywhere else.

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -59,6 +59,7 @@ class REPLWrapper:
         force_prompt_on_continuation: bool = False,
         echo: bool = False,
         extra_env: dict[str, Any] | None = None,
+        encoding: str = "utf-8",
     ) -> None:
         if isinstance(cmd_or_spawn, str):
             if extra_env:
@@ -70,7 +71,7 @@ class REPLWrapper:
                 cmd_or_spawn,
                 echo=echo,
                 codec_errors="ignore",
-                encoding="utf-8",
+                encoding=encoding,
                 env=env,
             )
         else:

--- a/tests/test_replwrap_init.py
+++ b/tests/test_replwrap_init.py
@@ -38,6 +38,24 @@ class TestREPLWrapperInit:
         )
         assert wrapper.child is mock_child
 
+    def test_custom_encoding_passed_to_spawnu(self) -> None:
+        """When encoding is specified, pexpect.spawnu is called with that encoding.
+
+        Reproduces issue #171: REPLWrapper hardcoded utf-8, breaking kernels like
+        gnuplot on Windows that output in a different encoding (e.g. cp1252).
+        """
+        mock_child = _make_child(echo=False)
+        with patch("metakernel.pexpect.spawnu", return_value=mock_child) as mock_spawn:
+            with patch.object(REPLWrapper, "_expect_prompt"):
+                with patch("atexit.register"):
+                    wrapper = REPLWrapper(
+                        "gnuplot", r"gnuplot>", None, encoding="cp1252"
+                    )
+        mock_spawn.assert_called_once_with(
+            "gnuplot", echo=False, codec_errors="ignore", encoding="cp1252", env=None
+        )
+        assert wrapper.child is mock_child
+
     def test_spawn_object_used_directly(self) -> None:
         """When cmd_or_spawn is not a str, it is assigned as child directly."""
         mock_child = _make_child(echo=False)


### PR DESCRIPTION
Closes #171.

## Summary

- `REPLWrapper` hardcoded `encoding="utf-8"` when spawning child processes. On Windows, programs like gnuplot output startup text in the system code page (e.g. `cp1252`), causing pexpect to time out waiting for the initial prompt and the kernel to never finish initialising.
- Adds an `encoding` parameter (default `"utf-8"` for backwards compatibility) that is forwarded to `pexpect.spawnu`.
- Adds a regression test verifying the encoding is passed through.
- Adds a Troubleshooting section to `docs/new_kernel.md` explaining the root cause and the fix.

## Test plan

- [x] `just test tests/test_replwrap_init.py` — new test `test_custom_encoding_passed_to_spawnu` passes
- [x] `just test` — full core suite passes