### PR TITLE
Fix %jigsaw failing to save files when workspace path includes a subdirectory

### DIFF
--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import os
 import random
 import string
 import urllib.request
@@ -52,6 +53,9 @@ class JigsawMagic(Magic):
         workspace_filename = workspace + ".xml"
         html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")
         html_filename = workspace + ".html"
+        html_dir = os.path.dirname(html_filename)
+        if html_dir:
+            os.makedirs(html_dir, exist_ok=True)
         html_text = html_text.replace("MYWORKSPACENAME", workspace_filename)
         with open(html_filename, "w") as fp:
             fp.write(html_text)

--- a/tests/magics/test_jigsaw_magic.py
+++ b/tests/magics/test_jigsaw_magic.py
@@ -19,9 +19,26 @@ def test_jigsaw_magic() -> None:
     assert os.path.isfile("workspace1.html"), "File does not exist: workspace1.html"
 
 
+@pytest.mark.skipif(not has_network(), reason="no network")
+def test_jigsaw_magic_with_path() -> None:
+    """Test that %jigsaw saves files in a subdirectory when path is given in workspace (issue #167)."""
+    kernel = get_kernel(EvalKernel)
+    asyncio.run(
+        kernel.do_execute(
+            "%jigsaw Processing --workspace jigsaw_test_subdir/workspace1"
+        )
+    )
+    assert os.path.isfile("jigsaw_test_subdir/workspace1.html"), (
+        "File does not exist: jigsaw_test_subdir/workspace1.html"
+    )
+
+
 def teardown() -> None:
+    import shutil
+
     for fname in ["workspace1.html"]:
         try:
             os.remove(fname)
         except OSError:
             pass
+    shutil.rmtree("jigsaw_test_subdir", ignore_errors=True)


### PR DESCRIPTION
## Summary

- Fixes `%jigsaw` raising `FileNotFoundError` when `--workspace` includes a path prefix (e.g. `--workspace subdir/myworkspace`) because the intermediate directory did not exist
- Adds `os.makedirs(..., exist_ok=True)` before writing the HTML file so the requested directory is created automatically

Closes #167

## Test plan

- [x] `test_jigsaw_magic` (existing) — workspace in current directory still works
- [x] `test_jigsaw_magic_with_path` (new) — workspace with a subdirectory path saves the HTML file in the correct location