### PR TITLE
Add kernel_javascript support to write kernel.js during kernelspec install

### DIFF
--- a/docs/new_kernel.md
+++ b/docs/new_kernel.md
@@ -87,6 +87,35 @@ Create `data_kernelspec/share/jupyter/kernels/my_kernel/kernel.json`:
 
 Optional keys include `"codemirror_mode"`, `"env"`, and `"interrupt_mode"`. See the [Jupyter kernel specification](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for the full list.
 
+## Syntax highlighting (kernel.js)
+
+To add syntax highlighting for your language in the notebook editor, set a `kernel_javascript` class attribute on your kernel. When `python -m my_kernel install` runs, MetaKernel writes this string to `kernel.js` alongside `kernel.json` in the kernelspec directory.
+
+The JavaScript should use CodeMirror's `defineSimpleMode` (or any other CodeMirror API) wrapped in a `define` call:
+
+```python
+class MyKernel(MetaKernel):
+    kernel_javascript = """
+define(
+  ['codemirror/lib/codemirror', 'codemirror/addon/mode/simple'],
+  function(CodeMirror, _) {
+    return {
+      onload: function() {
+        CodeMirror.defineSimpleMode('my_language', {
+          start: [
+            {regex: /#.*/, token: 'comment'},
+            {regex: /\\b(if|else|while|for)\\b/, token: 'keyword'},
+          ]
+        });
+      }
+    };
+  }
+);
+"""
+```
+
+The string is only written when it is non-empty after stripping whitespace, so leaving the attribute unset or blank skips the file entirely.
+
 ## Rich display output
 
 MetaKernel provides two complementary display paths depending on whether your kernel produces Python objects or raw MIME data.

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -974,7 +974,8 @@ class MetaKernelApp(IPKernelApp):
                 self.argv = filtered
 
             def start(self) -> None:
-                kernel_spec = self.kernel_class().kernel_json
+                instance = self.kernel_class()
+                kernel_spec = instance.kernel_json
                 if self.display_name is not None:
                     kernel_spec["display_name"] = self.display_name
                 with TemporaryDirectory() as td:
@@ -982,6 +983,12 @@ class MetaKernelApp(IPKernelApp):
                     os.mkdir(dirname)
                     with open(os.path.join(dirname, "kernel.json"), "w") as f:
                         json.dump(kernel_spec, f, sort_keys=True)
+                    if (
+                        hasattr(instance, "kernel_javascript")
+                        and instance.kernel_javascript.strip()
+                    ):
+                        with open(os.path.join(dirname, "kernel.js"), "w") as f:
+                            f.write(instance.kernel_javascript)
                     filenames = ["logo-64x64.png", "logo-32x32.png"]
                     name = self.kernel_class.__module__
                     for filename in filenames:

--- a/tests/test_metakernel_app.py
+++ b/tests/test_metakernel_app.py
@@ -116,6 +116,7 @@ class TestMetaKernelAppSubcommands:
         }
         mock_kernel_class = MagicMock()
         mock_kernel_class.return_value.kernel_json = kernel_json
+        mock_kernel_class.return_value.kernel_javascript = ""
         mock_kernel_class.__module__ = "metakernel"
 
         app = MetaKernelApp()
@@ -151,6 +152,7 @@ class TestMetaKernelAppSubcommands:
         }
         mock_kernel_class = MagicMock()
         mock_kernel_class.return_value.kernel_json = kernel_json
+        mock_kernel_class.return_value.kernel_javascript = ""
         mock_kernel_class.__module__ = "metakernel"
 
         app = MetaKernelApp()
@@ -171,6 +173,160 @@ class TestMetaKernelAppSubcommands:
         assert "install" in cmd
         assert "--user" in cmd
 
+    def test_install_start_writes_kernel_js_when_kernel_javascript_set(self) -> None:
+        import os
+
+        kernel_json = {
+            "argv": ["python", "-m", "test_kernel"],
+            "display_name": "Test Kernel",
+            "language": "test",
+            "name": "test-kernel",
+        }
+        mock_instance = MagicMock()
+        mock_instance.kernel_json = kernel_json
+        mock_instance.kernel_javascript = "define([], function() {});"
+        mock_kernel_class = MagicMock(return_value=mock_instance)
+        mock_kernel_class.__module__ = "metakernel"
+
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        KernelInstallerApp.kernel_class = mock_kernel_class
+
+        installer = KernelInstallerApp()
+        installer.argv = []
+
+        written_files: list[str] = []
+        original_open = open
+
+        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+            written_files.append(os.path.basename(path))
+            return original_open(path, mode, **kwargs)
+
+        with (
+            patch("subprocess.check_call"),
+            patch("builtins.open", side_effect=capture_open),
+        ):
+            installer.start()
+
+        assert "kernel.js" in written_files
+
+    def test_install_start_skips_kernel_js_when_kernel_javascript_empty(self) -> None:
+        import os
+
+        kernel_json = {
+            "argv": ["python", "-m", "test_kernel"],
+            "display_name": "Test Kernel",
+            "language": "test",
+            "name": "test-kernel",
+        }
+        mock_instance = MagicMock()
+        mock_instance.kernel_json = kernel_json
+        mock_instance.kernel_javascript = "   "
+        mock_kernel_class = MagicMock(return_value=mock_instance)
+        mock_kernel_class.__module__ = "metakernel"
+
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        KernelInstallerApp.kernel_class = mock_kernel_class
+
+        installer = KernelInstallerApp()
+        installer.argv = []
+
+        written_files: list[str] = []
+        original_open = open
+
+        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+            written_files.append(os.path.basename(path))
+            return original_open(path, mode, **kwargs)
+
+        with (
+            patch("subprocess.check_call"),
+            patch("builtins.open", side_effect=capture_open),
+        ):
+            installer.start()
+
+        assert "kernel.js" not in written_files
+
+    def test_install_start_skips_kernel_js_when_kernel_javascript_absent(self) -> None:
+        import os
+
+        kernel_json = {
+            "argv": ["python", "-m", "test_kernel"],
+            "display_name": "Test Kernel",
+            "language": "test",
+            "name": "test-kernel",
+        }
+        mock_instance = MagicMock(spec=["kernel_json"])
+        mock_instance.kernel_json = kernel_json
+        mock_kernel_class = MagicMock(return_value=mock_instance)
+        mock_kernel_class.__module__ = "metakernel"
+
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        KernelInstallerApp.kernel_class = mock_kernel_class
+
+        installer = KernelInstallerApp()
+        installer.argv = []
+
+        written_files: list[str] = []
+        original_open = open
+
+        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+            written_files.append(os.path.basename(path))
+            return original_open(path, mode, **kwargs)
+
+        with (
+            patch("subprocess.check_call"),
+            patch("builtins.open", side_effect=capture_open),
+        ):
+            installer.start()
+
+        assert "kernel.js" not in written_files
+
+    def test_install_start_writes_correct_kernel_js_content(self) -> None:
+        kernel_json = {
+            "argv": ["python", "-m", "test_kernel"],
+            "display_name": "Test Kernel",
+            "language": "test",
+            "name": "test-kernel",
+        }
+        js_content = "define([], function() { return {}; });"
+        mock_instance = MagicMock()
+        mock_instance.kernel_json = kernel_json
+        mock_instance.kernel_javascript = js_content
+        mock_kernel_class = MagicMock(return_value=mock_instance)
+        mock_kernel_class.__module__ = "metakernel"
+
+        app = MetaKernelApp()
+        KernelInstallerApp, _ = app.subcommands["install"]
+        KernelInstallerApp.kernel_class = mock_kernel_class
+
+        installer = KernelInstallerApp()
+        installer.argv = []
+
+        import io
+        import os
+
+        written: dict[str, str] = {}
+        original_open = open
+
+        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+            if "w" in mode and os.path.basename(path) == "kernel.js":
+                buf = io.StringIO()
+                buf.close = lambda: None  # type: ignore[method-assign]
+                written["kernel.js"] = buf
+                return buf
+            return original_open(path, mode, **kwargs)
+
+        with (
+            patch("subprocess.check_call"),
+            patch("builtins.open", side_effect=capture_open),
+        ):
+            installer.start()
+
+        assert "kernel.js" in written
+        assert written["kernel.js"].getvalue() == js_content
+
     def test_install_start_exits_on_failure(self) -> None:
         import subprocess
 
@@ -182,6 +338,7 @@ class TestMetaKernelAppSubcommands:
         }
         mock_kernel_class = MagicMock()
         mock_kernel_class.return_value.kernel_json = kernel_json
+        mock_kernel_class.return_value.kernel_javascript = ""
         mock_kernel_class.__module__ = "metakernel"
 
         app = MetaKernelApp()

--- a/tests/test_metakernel_app.py
+++ b/tests/test_metakernel_app.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -198,7 +199,7 @@ class TestMetaKernelAppSubcommands:
         written_files: list[str] = []
         original_open = open
 
-        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+        def capture_open(path: str, mode: str = "r", **kwargs: Any) -> Any:
             written_files.append(os.path.basename(path))
             return original_open(path, mode, **kwargs)
 
@@ -235,7 +236,7 @@ class TestMetaKernelAppSubcommands:
         written_files: list[str] = []
         original_open = open
 
-        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+        def capture_open(path: str, mode: str = "r", **kwargs: Any) -> Any:
             written_files.append(os.path.basename(path))
             return original_open(path, mode, **kwargs)
 
@@ -271,7 +272,7 @@ class TestMetaKernelAppSubcommands:
         written_files: list[str] = []
         original_open = open
 
-        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+        def capture_open(path: str, mode: str = "r", **kwargs: Any) -> Any:
             written_files.append(os.path.basename(path))
             return original_open(path, mode, **kwargs)
 
@@ -307,10 +308,10 @@ class TestMetaKernelAppSubcommands:
         import io
         import os
 
-        written: dict[str, str] = {}
+        written: dict[str, io.StringIO] = {}
         original_open = open
 
-        def capture_open(path: str, mode: str = "r", **kwargs: object) -> object:
+        def capture_open(path: str, mode: str = "r", **kwargs: Any) -> Any:
             if "w" in mode and os.path.basename(path) == "kernel.js":
                 buf = io.StringIO()
                 buf.close = lambda: None  # type: ignore[method-assign]


### PR DESCRIPTION
## References

Replaces and closes #194.

## Description

Kernels can now set a `kernel_javascript` class attribute. When `python -m my_kernel install` runs, MetaKernel writes that string to `kernel.js` alongside `kernel.json` in the kernelspec directory, enabling CodeMirror syntax highlighting and other notebook-editor customisations without a separate packaging step.

## Changes

- `metakernel/_metakernel.py`: instantiate the kernel class once in `KernelInstallerApp.start()`; if the instance has a non-empty `kernel_javascript` attribute, write it to `kernel.js` in the temporary kernelspec directory before calling `jupyter kernelspec install`.
- `tests/test_metakernel_app.py`: four new tests covering the happy path (file written, correct content), whitespace-only string (skipped), and absent attribute (skipped). Fixed three existing tests to set `kernel_javascript = ""` on their mock instances so the new branch does not interfere.
- `docs/new_kernel.md`: added a "Syntax highlighting (kernel.js)" section documenting the new attribute with a CodeMirror `defineSimpleMode` example.

## Backwards-incompatible changes

None

## Testing

New and existing tests in `tests/test_metakernel_app.py` all pass (`just test tests/test_metakernel_app.py`).

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)