### PR TITLE
Fix %%tutor loading all iframes immediately (closes #68)

### DIFF
--- a/examples/Tutor Magic in IPython.ipynb
+++ b/examples/Tutor Magic in IPython.ipynb
@@ -19,15 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true,
-    "execution": {
-     "iopub.execute_input": "2026-03-12T15:20:32.555444Z",
-     "iopub.status.busy": "2026-03-12T15:20:32.555132Z",
-     "iopub.status.idle": "2026-03-12T15:20:32.635976Z",
-     "shell.execute_reply": "2026-03-12T15:20:32.635585Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from metakernel import register_ipython_magics\n",
@@ -47,30 +39,18 @@
    "execution_count": 2,
    "metadata": {
     "collapsed": false,
-    "execution": {
-     "iopub.execute_input": "2026-03-12T15:20:32.637798Z",
-     "iopub.status.busy": "2026-03-12T15:20:32.637681Z",
-     "iopub.status.idle": "2026-03-12T15:20:32.640933Z",
-     "shell.execute_reply": "2026-03-12T15:20:32.640674Z"
+    "jupyter": {
+     "outputs_hidden": false
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"500\"\n",
-       "            src=\"https://pythontutor.com/iframe-embed.html#code=%0Amylist%20%3D%20%5B%5D%0A%0Afor%20i%20in%20range%2810%29%3A%0A%20%20%20%20mylist.append%28i%20%2A%2A%202%29%0A&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=3&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=350&codeDivHeight=400\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
+       "<div><button onclick=\"this.parentNode.innerHTML='<iframe src=&quot;https://pythontutor.com/iframe-embed.html#code=%0Amylist%20%3D%20%5B%5D%0A%0Afor%20i%20in%20range%2810%29%3A%0A%20%20%20%20mylist.append%28i%20%2A%2A%202%29%0A&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=3&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=350&codeDivHeight=400&quot; width=&quot;100%&quot; height=&quot;500&quot; frameborder=&quot;0&quot;></iframe>'\">Run in Online Python Tutor</button></div>"
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x10c486c20>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -87,9 +67,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><button onclick=\"this.parentNode.innerHTML='<iframe src=&quot;https://pythontutor.com/iframe-embed.html#code=%0Adata%20%3D%20%7B%7D%0A%0Afor%20i%20in%20range%2810%29%3A%0A%20%20%20%20data%5Bstr%28i%29%5D%20%3D%201%0A&origin=opt-frontend.js&cumulative=false&heapPrimitives=false&textReferences=false&py=3&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=350&codeDivHeight=400&quot; width=&quot;100%&quot; height=&quot;500&quot; frameborder=&quot;0&quot;></iframe>'\">Run in Online Python Tutor</button></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%tutor\n",
+    "\n",
+    "data = {}\n",
+    "\n",
+    "for i in range(10):\n",
+    "    data[str(i)] = 1"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "source": [
     "Try it out!"
@@ -98,7 +108,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -116,5 +126,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/metakernel/magics/tutor_magic.py
+++ b/metakernel/magics/tutor_magic.py
@@ -100,7 +100,7 @@ class TutorMagic(Magic):
             f'">Run in Online Python Tutor</button>'
             f"</div>"
         )
-        self.kernel.Display(HTML(html))
+        self.kernel.Display(HTML(html))  # type: ignore[no-untyped-call]
         self.evaluate = False
 
 

--- a/metakernel/magics/tutor_magic.py
+++ b/metakernel/magics/tutor_magic.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 # -----------------------------------------------------------------------------
 from urllib.parse import quote
 
-from IPython.display import IFrame
+from IPython.display import HTML
 
 from metakernel import Magic, MetaKernel, option
 
@@ -88,8 +88,19 @@ class TutorMagic(Magic):
         elif language == "javascript":
             url += "py=js&rawInputLstJSON=%5B%5D&curInstr=0&codeDivWidth=350&codeDivHeight=400"
 
-        # Display the results in the output area
-        self.kernel.Display(IFrame(url, height=500, width="100%"))
+        # Display a button that loads the iframe on click (avoids simultaneous
+        # requests from multiple %%tutor cells in a static notebook).
+        escaped_url = url.replace('"', "&quot;")
+        html = (
+            f"<div>"
+            f'<button onclick="'
+            f"this.parentNode.innerHTML='<iframe src=&quot;{escaped_url}&quot; "
+            f"width=&quot;100%&quot; height=&quot;500&quot; "
+            f"frameborder=&quot;0&quot;></iframe>'"
+            f'">Run in Online Python Tutor</button>'
+            f"</div>"
+        )
+        self.kernel.Display(HTML(html))
         self.evaluate = False
 
 

--- a/tests/magics/test_tutor_magic.py
+++ b/tests/magics/test_tutor_magic.py
@@ -6,7 +6,7 @@ from tests.utils import EvalKernel, get_kernel
 
 
 def _run_tutor(code: str, language: str | None = None):
-    """Helper: run cell_tutor and return the IFrame passed to Display."""
+    """Helper: run cell_tutor and return the HTML object passed to Display."""
     kernel = get_kernel(EvalKernel)
     magic = kernel.cell_magics["tutor"]
     magic.code = code
@@ -18,45 +18,57 @@ def _run_tutor(code: str, language: str | None = None):
     return magic, captured.get("obj")
 
 
+def _get_url(html_obj) -> str:
+    """Extract the pythontutor URL embedded in the HTML button output."""
+    return html_obj.data
+
+
 def test_tutor_python3_url() -> None:
     """%%tutor with python3 builds a URL with py=3."""
-    _, iframe = _run_tutor("x = 1", language="python3")
-    assert "py=3" in iframe.src
-    assert "pythontutor.com" in iframe.src
+    _, html = _run_tutor("x = 1", language="python3")
+    assert "py=3" in _get_url(html)
+    assert "pythontutor.com" in _get_url(html)
 
 
 def test_tutor_python_alias_url() -> None:
     """'python' is an alias for python3 and produces the same py=3 URL."""
-    _, iframe_py = _run_tutor("x = 1", language="python")
-    _, iframe_py3 = _run_tutor("x = 1", language="python3")
-    assert "py=3" in iframe_py.src
-    assert iframe_py.src == iframe_py3.src
+    _, html_py = _run_tutor("x = 1", language="python")
+    _, html_py3 = _run_tutor("x = 1", language="python3")
+    assert "py=3" in _get_url(html_py)
+    assert _get_url(html_py) == _get_url(html_py3)
 
 
 def test_tutor_python2_url() -> None:
     """%%tutor with python2 builds a URL with py=2."""
-    _, iframe = _run_tutor("x = 1", language="python2")
-    assert "py=2" in iframe.src
+    _, html = _run_tutor("x = 1", language="python2")
+    assert "py=2" in _get_url(html)
 
 
 def test_tutor_java_url() -> None:
     """%%tutor with java builds a URL with py=java."""
-    _, iframe = _run_tutor('System.out.println("hi");', language="java")
-    assert "py=java" in iframe.src
+    _, html = _run_tutor('System.out.println("hi");', language="java")
+    assert "py=java" in _get_url(html)
 
 
 def test_tutor_javascript_url() -> None:
     """%%tutor with javascript builds a URL with py=js."""
-    _, iframe = _run_tutor("var x = 1;", language="javascript")
-    assert "py=js" in iframe.src
+    _, html = _run_tutor("var x = 1;", language="javascript")
+    assert "py=js" in _get_url(html)
 
 
 def test_tutor_code_encoded_in_url() -> None:
-    """The cell code is URL-encoded and present in the iframe URL."""
-    _, iframe = _run_tutor("a = 1\nb = 2", language="python3")
-    # URL-encoded newline
-    assert "a%20%3D%201" in iframe.src or "a+%3D+1" in iframe.src or "a" in iframe.src
-    assert "pythontutor.com" in iframe.src
+    """The cell code is URL-encoded and present in the button HTML."""
+    _, html = _run_tutor("a = 1\nb = 2", language="python3")
+    assert "pythontutor.com" in _get_url(html)
+
+
+def test_tutor_button_rendered() -> None:
+    """%%tutor renders a button that loads the iframe on click."""
+    _, html = _run_tutor("x = 1", language="python3")
+    data = _get_url(html)
+    assert "<button" in data
+    assert "onclick" in data
+    assert "<iframe" in data
 
 
 def test_tutor_evaluate_set_false() -> None:
@@ -76,7 +88,7 @@ def test_tutor_default_language_from_kernel() -> None:
         kernel, "Display", side_effect=lambda obj: captured.update({"obj": obj})
     ):
         magic.cell_tutor(language=None)
-    assert "py=3" in captured["obj"].src
+    assert "py=3" in captured["obj"].data
 
 
 def test_tutor_unsupported_language_raises() -> None:

--- a/tests/magics/test_tutor_magic.py
+++ b/tests/magics/test_tutor_magic.py
@@ -20,7 +20,7 @@ def _run_tutor(code: str, language: str | None = None):
 
 def _get_url(html_obj) -> str:
     """Extract the pythontutor URL embedded in the HTML button output."""
-    return html_obj.data
+    return str(html_obj.data)
 
 
 def test_tutor_python3_url() -> None:


### PR DESCRIPTION
## References

closes #68

## Description

`%%tutor` previously rendered an `IFrame` immediately on cell execution. When a static notebook contains multiple `%%tutor` cells, all iframes load at once, which can result in the server rejecting simultaneous requests.

## Changes

- Replace the auto-loading `IFrame` with an HTML `<button>` that loads the pythontutor.com iframe only when clicked
- Update tests to assert against the new `HTML` output instead of `IFrame.src`
- Add a test verifying the button/onclick/iframe markup is present
- Update the example notebook output to reflect the new HTML output

## Backwards-incompatible changes

The output of `%%tutor` cells changes from an immediately-rendered iframe to a clickable button. Existing saved notebook outputs will show the old iframe; re-running the cell will produce the new button.

## Testing

- Existing test suite (`just test`) passes (479 passed, 13 skipped)
- Tutor magic test file updated and all 11 tests pass

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)