### PR TITLE
Fix %px/%px errors not surfacing as proper error messages (closes #61)

### DIFF
--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from metakernel import Magic, MetaKernel, option
+from metakernel import ExceptionWrapper, Magic, MetaKernel, option
 
 
 class Slice:
@@ -382,6 +382,15 @@ kernels['{kernel_name}'] = {class_name}()
                 return None
         except Exception:
             pass
+        # If every remote result is an ExceptionWrapper, surface the first one
+        # as a proper error so MetaKernel reports it as an error message rather
+        # than formatting the list as plain output (issue #61).
+        if (
+            isinstance(self.retval, list)
+            and self.retval
+            and all(isinstance(r, ExceptionWrapper) for r in self.retval)
+        ):
+            return self.retval[0]
         return self.retval
 
 

--- a/tests/magics/test_parallel_magic.py
+++ b/tests/magics/test_parallel_magic.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from metakernel.magics.parallel_magic import ParallelMagic
-from tests.utils import EvalKernel, get_kernel, get_log_text
+from tests.utils import EvalKernel, capture_send_messages, get_kernel, get_log_text
 
 try:
     import ipyparallel  # type: ignore[import-untyped]
@@ -28,6 +28,37 @@ def test_parallel_magic() -> None:
     asyncio.run(kernel.do_execute("%px cluster_rank", False))
     results = get_log_text(kernel)
     assert "[0, 1, 2]" in results, results
+
+
+@pytest.mark.skipif(ipyparallel is None, reason="Requires ipyparallel")
+def test_px_error_reports_exception_not_noisy_traceback() -> None:
+    """%%px with failing code should report the remote error, not a noisy
+    'Error in calling magic' wrapper with full Python traceback (issue #61)."""
+    kernel = get_kernel(EvalKernel)
+    asyncio.run(
+        kernel.do_execute("%parallel metakernel_python MetaKernelPython", False)
+    )
+
+    with capture_send_messages(kernel) as messages:
+        asyncio.run(kernel.do_execute("%%px\nundefined_variable_xyz_issue61", False))
+
+    all_text = "\n".join(
+        m.get("text", "")
+        + m.get("evalue", "")
+        + str(m.get("traceback", []))
+        + str(m.get("data", {}))
+        for _, m in messages
+    )
+
+    assert "Error in calling magic" not in all_text, (
+        f"Got noisy call_magic wrapper instead of a proper error message:\n{all_text}"
+    )
+    # The response should be an error message type, not just execute_result
+    msg_types = [t for t, _ in messages]
+    assert "error" in msg_types, (
+        f"Expected an 'error' message type but got {msg_types}.\n"
+        f"Full output:\n{all_text}"
+    )
 
 
 # Starting the cluster from here doesn't work with pytest


### PR DESCRIPTION
## References

closes #61

## Description

When `%px` or `%%px` executed code that raised an error on the remote engines, the error was silently converted to a list of `ExceptionWrapper` objects and displayed as a plain `execute_result` — an ugly, unformatted text blob — instead of a proper Jupyter error cell with a red traceback.

After this fix, errors from `%px`/`%%px` are surfaced as proper error messages:

![%px y raises a NameError, now shown as a proper red error cell with traceback](https://github.com/calysto/metakernel/assets/screenshot-issue-61.png)

**Before:** error shown as `[NameError: ("name 'y' is not defined",)\n ['Traceback...'], ...]` in plain output cell.

**After:** error displayed as a proper Jupyter error cell with traceback (see screenshot).

<img width="579" height="382" alt="image" src="https://github.com/user-attachments/assets/61af2a40-14eb-43fa-94c2-69fe04c23361" />


## Changes

- `metakernel/magics/parallel_magic.py`: In `ParallelMagic.post_process`, detect when all remote results are `ExceptionWrapper` objects and return the first one directly, so `MetaKernel.post_execute` routes it through the proper error-message path.
- `tests/magics/test_parallel_magic.py`: Add `test_px_error_reports_exception_not_noisy_traceback` — a cluster-based integration test (requires `just test-parallel`) that runs `%%px` with an undefined variable and asserts the response is an `'error'` message type, not `'execute_result'`.

## Backwards-incompatible changes

None

## Testing

New integration test `test_px_error_reports_exception_not_noisy_traceback` exercises the fix end-to-end against a live ipcluster. Run with:

```
just test-parallel tests/magics/test_parallel_magic.py::test_px_error_reports_exception_not_noisy_traceback
```

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6