### PR TITLE
Add schedule_display_output for pushing messages to frontends outside execution

### DIFF
--- a/docs/new_kernel.md
+++ b/docs/new_kernel.md
@@ -161,6 +161,48 @@ def do_execute_direct(self, code):
 
 As a convenience, `self.Display()` also accepts a raw MIME bundle dict and routes it to `DisplayData` automatically, so you can pass MIME data through the same call site as Python objects.
 
+## Pushing output from background threads
+
+MetaKernel kernels can send output to all connected frontends at any time — even when no cell is being executed. This is useful for kernels that wrap an application that emits events, periodic status updates, or asynchronous notifications.
+
+Use `self.schedule_display_output(callback)` to schedule a callable on the kernel's main IO loop. Because ZMQ sockets are not thread-safe, calling `self.Print(...)` directly from a background thread is unsafe; `schedule_display_output` routes the call through Tornado's thread-safe `add_callback`, ensuring the message is delivered correctly.
+
+```python
+import threading
+import time
+
+from metakernel import MetaKernel
+
+
+class MyKernel(MetaKernel):
+    # ... (required attributes omitted for brevity)
+
+    def start(self):
+        super().start()
+        t = threading.Thread(target=self._background_monitor, daemon=True)
+        t.start()
+
+    def _background_monitor(self):
+        """Poll the connected application every 10 seconds and forward any output."""
+        while True:
+            time.sleep(10)
+            message = self._poll_app()   # your application-specific call
+            if message:
+                self.schedule_display_output(
+                    lambda msg=message: self.Print(msg)
+                )
+
+    def _poll_app(self):
+        return "periodic status update"
+
+    def do_execute_direct(self, code, silent=False):
+        return self._poll_app()
+```
+
+The callback receives no arguments and is called on the main thread, so it can safely call `self.Print`, `self.Write`, `self.Display`, `self.DisplayData`, or `self.Error`.
+
+When `io_loop` is not available (for example in unit tests), the callback is invoked directly instead.
+
 ## Adding custom magics
 
 Place magic files in a `magics/` subpackage alongside your kernel module. Each file should be named `{name}_magic.py` and define a class that inherits from `Magic`. Line magics are methods named `line_{name}` and cell magics are `cell_{name}`:

--- a/docs/new_magic.md
+++ b/docs/new_magic.md
@@ -201,6 +201,32 @@ Inside a magic method, use the following helpers on `self.kernel`:
 
 : Read a variable from the kernel's namespace.
 
+`self.kernel.schedule_display_output(callback)`
+
+: Schedule a zero-argument callable to run on the kernel's main IO loop. Use this when you need to send output from a background thread (for example, in response to an event from a connected application). ZMQ sockets are not thread-safe, so calling `Print` or `Display` directly from a background thread is unsafe — `schedule_display_output` routes the call through Tornado's thread-safe `add_callback`:
+
+````
+```python
+import threading
+
+def line_watch(self, interval="5"):
+    """
+    %watch [interval]
+
+    Start a background thread that prints a status message every *interval* seconds.
+    """
+    def _monitor():
+        import time
+        while True:
+            time.sleep(float(interval))
+            self.kernel.schedule_display_output(
+                lambda: self.kernel.Print("still running…")
+            )
+
+    threading.Thread(target=_monitor, daemon=True).start()
+```
+````
+
 `self.code`
 
 : The raw cell body (cell magics only); available after `call_magic` sets it, or directly inside `cell_*` methods.

--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -12,7 +12,7 @@ import sys
 import warnings
 from collections import OrderedDict
 from subprocess import CalledProcessError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import comm
 from ipykernel.kernelapp import IPKernelApp
@@ -814,6 +814,38 @@ class MetaKernel(Kernel):
             self.log.info(message.rstrip())
         else:
             self.send_response(self.iopub_socket, "stream", stream_content)
+
+    def schedule_display_output(self, callback: Callable[[], None]) -> None:
+        """Schedule a display output callback to run on the kernel's main IO loop.
+
+        Use this to send output to the frontend from a background thread when
+        no execution is in progress. The callback is executed on the kernel's
+        main IO loop, ensuring thread safety with ZMQ sockets.
+
+        Example::
+
+            import threading
+            import time
+
+            def background_task(kernel):
+                while True:
+                    time.sleep(10)
+                    kernel.schedule_display_output(
+                        lambda: kernel.Print("Periodic update from background!")
+                    )
+
+            threading.Thread(target=background_task, args=(self,), daemon=True).start()
+
+        Args:
+            callback: A callable that will be invoked on the main IO loop.
+                      Typically calls methods like :meth:`Print`, :meth:`Write`,
+                      :meth:`Display`, :meth:`DisplayData`, or :meth:`Error`.
+        """
+        io_loop = getattr(self, "io_loop", None)
+        if io_loop is not None:
+            io_loop.add_callback(callback)
+        else:
+            callback()
 
     ##############################
     # Private API and methods not likely to be overridden

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -953,6 +953,74 @@ class TestDisplayData:
         mock_send.assert_not_called()
 
 
+class TestScheduleDisplayOutput:
+    """Tests for schedule_display_output (issue #198)."""
+
+    def test_calls_callback_directly_without_io_loop(self) -> None:
+        """Callback is invoked immediately when io_loop is absent (e.g. in tests)."""
+        kernel = get_kernel()
+        assert not hasattr(kernel, "io_loop")
+        called = []
+        kernel.schedule_display_output(lambda: called.append(True))
+        assert called == [True]
+
+    def test_sends_iopub_message_via_callback(self) -> None:
+        """schedule_display_output triggers Print which sends a stream message."""
+        kernel = get_kernel()
+        with unittest.mock.patch.object(kernel, "send_response") as mock_send:
+            kernel.schedule_display_output(
+                lambda: kernel.Print("hello from background")
+            )
+        mock_send.assert_called_once_with(
+            kernel.iopub_socket,
+            "stream",
+            {"name": "stdout", "text": "hello from background\n"},
+        )
+
+    def test_uses_io_loop_add_callback_when_available(self) -> None:
+        """When io_loop is present, add_callback is used instead of a direct call."""
+        kernel = get_kernel()
+        mock_io_loop = unittest.mock.Mock()
+        kernel.io_loop = mock_io_loop  # type: ignore[attr-defined]
+
+        def cb() -> None:
+            pass
+
+        kernel.schedule_display_output(cb)
+        mock_io_loop.add_callback.assert_called_once_with(cb)
+
+    def test_background_thread_sends_message(self) -> None:
+        """Callback scheduled from a background thread is executed and sends output."""
+        import threading
+
+        kernel = get_kernel()
+        sent: list[tuple[str, dict[str, Any]]] = []
+        original = kernel.send_response
+
+        def _capture(
+            socket: Any, msg_type: str, content: dict[str, Any], **kwargs: Any
+        ) -> Any:
+            sent.append((msg_type, content))
+            return original(socket, msg_type, content, **kwargs)
+
+        kernel.send_response = _capture  # type: ignore[method-assign]
+
+        done = threading.Event()
+
+        def background() -> None:
+            kernel.schedule_display_output(lambda: kernel.Print("from thread"))
+            done.set()
+
+        t = threading.Thread(target=background)
+        t.start()
+        t.join(timeout=2)
+        assert done.is_set(), "background thread did not complete"
+        assert any(
+            msg_type == "stream" and content.get("text") == "from thread\n"
+            for msg_type, content in sent
+        )
+
+
 def teardown() -> None:
     if os.path.exists("TEST.txt"):
         os.remove("TEST.txt")

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -981,7 +981,7 @@ class TestScheduleDisplayOutput:
         """When io_loop is present, add_callback is used instead of a direct call."""
         kernel = get_kernel()
         mock_io_loop = unittest.mock.Mock()
-        kernel.io_loop = mock_io_loop  # type: ignore[attr-defined]
+        kernel.io_loop = mock_io_loop
 
         def cb() -> None:
             pass


### PR DESCRIPTION
## References

closes #198

## Description

Kernel authors sometimes need to push output to all connected frontends from a background thread — for example, when wrapping an application that emits periodic events or async notifications. Previously there was no supported way to do this.

This PR adds `MetaKernel.schedule_display_output(callback)`, which schedules a zero-argument callable on the kernel's main Tornado IO loop. Because ZMQ sockets are not thread-safe, calling `Print`/`Display`/etc. directly from a background thread is unsafe; routing through `io_loop.add_callback` (Tornado's thread-safe mechanism) ensures the message is delivered correctly to all frontends even when no cell execution is in progress. When `io_loop` is unavailable (e.g. in unit tests), the callback is invoked directly.

## Changes

- `metakernel/_metakernel.py`: add `schedule_display_output(callback)` method; add `Callable` to typing imports
- `tests/test_metakernel.py`: four new tests in `TestScheduleDisplayOutput` covering the no-io_loop fallback, iopub message delivery, io_loop delegation, and a real background thread
- `docs/new_kernel.md`: new "Pushing output from background threads" section with a complete example
- `docs/new_magic.md`: new `schedule_display_output` entry in the kernel output helpers reference

## Backwards-incompatible changes

None

## Testing

New unit tests added. All existing tests pass (one pre-existing failure in `test_px_error_reports_exception_not_noisy_traceback` unrelated to this change).

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)