### PR TITLE
Add ruff S (flake8-bandit) security checks

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -146,7 +146,7 @@ class MetaKernel(Kernel):
             # Write has already been set
             try:
                 sys.stdout.write = self.Write  # type: ignore[method-assign]
-            except Exception:
+            except Exception:  # noqa: S110
                 pass  # Can't change stdout
         self.redirect_to_log = False
         self.shell = None
@@ -184,7 +184,7 @@ class MetaKernel(Kernel):
                 return c
 
             comm.create_comm = _create_comm_with_kernel
-        except Exception:
+        except Exception:  # noqa: S110
             pass
 
         self.hist_file = get_history_file(self)

--- a/metakernel/magic.py
+++ b/metakernel/magic.py
@@ -238,7 +238,7 @@ def _parse_args(
     for key, value in kwargs.items():
         try:
             kwargs[key] = safe_eval(value)
-        except Exception:
+        except Exception:  # noqa: S110
             pass
 
     return new_args, kwargs

--- a/metakernel/magics/activity_magic.py
+++ b/metakernel/magics/activity_magic.py
@@ -34,7 +34,7 @@ class Activity:
             filename = os.path.expanduser(filename)
         filename = os.path.abspath(filename)
         self.filename = filename
-        assert self.filename is not None
+        assert self.filename is not None  # noqa: S101
         with open(self.filename) as fp:
             json_text = "".join(fp.readlines())
         self.load_json(json_text)
@@ -154,7 +154,7 @@ class Activity:
         self.handle_submit(sender)
         self.last_id = self.questions[self.index].id
         data = {}
-        assert self.results_filename is not None
+        assert self.results_filename is not None  # noqa: S101
         with open(self.results_filename) as fp:
             line = fp.readline()
             while line:
@@ -189,7 +189,7 @@ class Activity:
     def handle_submit(self, sender: Any) -> None:
         import portalocker
 
-        assert self.results_filename is not None
+        assert self.results_filename is not None  # noqa: S101
         with portalocker.Lock(self.results_filename, "a+") as g:
             g.write(
                 f"{self.id}::{getpass.getuser()}::{datetime.datetime.today()}::{sender.description}\n"
@@ -330,8 +330,8 @@ class ActivityMagic(Magic):
         activity = Activity()
         activity.load(filename)
         # Make sure results file is writable:
-        assert activity.results_filename is not None
-        os.chmod(activity.results_filename, 0o777)
+        assert activity.results_filename is not None  # noqa: S101
+        os.chmod(activity.results_filename, 0o777)  # noqa: S103
         # Ok, let's test it (MetaKernel):
         self.line_activity(filename)
         self.evaluate = False

--- a/metakernel/magics/help_magic.py
+++ b/metakernel/magics/help_magic.py
@@ -84,7 +84,7 @@ class HelpMagic(Magic):
                 if minfo["args"]:
                     info = self.kernel.parse_code(minfo["args"])
                 elif magic:
-                    assert isinstance(magic, Magic)
+                    assert isinstance(magic, Magic)  # noqa: S101
                     return magic.get_help(minfo["type"], minfo["name"], level)
 
             else:
@@ -95,14 +95,14 @@ class HelpMagic(Magic):
                 elif minfo["args"]:
                     info = self.kernel.parse_code(minfo["args"])
                 elif magic:
-                    assert isinstance(magic, Magic)
+                    assert isinstance(magic, Magic)  # noqa: S101
                     return magic.get_help(minfo["type"], minfo["name"], level)
                 else:
                     return "No such {} magic named '{}', so can't really help with that".format(
                         minfo["type"], minfo["name"]
                     )
             if magic:
-                assert isinstance(magic, Magic)
+                assert isinstance(magic, Magic)  # noqa: S101
                 the_help = magic.get_help_on(info, level)
                 self.kernel.log.error("got")
                 self.kernel.log.error(the_help)

--- a/metakernel/magics/macro_magic.py
+++ b/metakernel/magics/macro_magic.py
@@ -125,7 +125,7 @@ class MacroMagic(Magic):
             try:
                 with open(macro_file) as mf:
                     data = ast.literal_eval(mf.read())
-            except Exception:
+            except Exception:  # noqa: S112
                 continue
             self.learned.update(data)
 

--- a/metakernel/magics/parallel_magic.py
+++ b/metakernel/magics/parallel_magic.py
@@ -380,7 +380,7 @@ kernels['{kernel_name}'] = {class_name}()
             ## any will crash on numpy arrays
             if isinstance(self.retval, list) and not any(self.retval):
                 return None
-        except Exception:
+        except Exception:  # noqa: S110
             pass
         # If every remote result is an ExceptionWrapper, surface the first one
         # as a proper error so MetaKernel reports it as an error message rather

--- a/metakernel/magics/shell_magic.py
+++ b/metakernel/magics/shell_magic.py
@@ -50,7 +50,7 @@ class ShellMagic(Magic):
     def eval(self, cmd: str, incremental: bool = False) -> str:
         if self.repl is None:
             self.start_process()
-        assert self.repl is not None
+        assert self.repl is not None  # noqa: S101
         stream_handler = self.kernel.Print if incremental else None
         return self.repl.run_command(cmd, timeout=None, stream_handler=stream_handler)
 

--- a/metakernel/parser.py
+++ b/metakernel/parser.py
@@ -110,7 +110,7 @@ class Parser:
             info["column"] = col = 0
 
         _match = re.search(self.id_regex, line)
-        assert _match is not None
+        assert _match is not None  # noqa: S101
         obj = _match.group()
 
         full_obj = obj
@@ -212,7 +212,7 @@ class Parser:
             info["name"] = "help"
             regex = rf"(\{self.help_suffix}+)\Z"
             match = re.search(regex, code.strip(), re.UNICODE)
-            assert match is not None
+            assert match is not None  # noqa: S101
             suf = match.group()
             info["prefix"] = ""
             info["type"] = types[len(suf)]
@@ -313,7 +313,7 @@ def _listdir(root: str) -> list[str]:
             if os.path.isdir(path):
                 name += os.sep
             res.append(name)
-    except Exception:
+    except Exception:  # noqa: S110
         pass  # no need to report invalid paths
     return res
 

--- a/metakernel/process_metakernel.py
+++ b/metakernel/process_metakernel.py
@@ -53,7 +53,7 @@ class ProcessMetaKernel(MetaKernel):
 
     @property
     def banner(self) -> str:  # type:ignore[override]
-        assert self._banner is not None
+        assert self._banner is not None  # noqa: S101
         return self._banner
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -97,7 +97,7 @@ class ProcessMetaKernel(MetaKernel):
             if self.wrapper is not None:
                 try:
                     self.wrapper.terminate()
-                except Exception:
+                except Exception:  # noqa: S110
                     pass
             self.restart_kernel()
             self.reload_magics()

--- a/metakernel_echo/hatch_build.py
+++ b/metakernel_echo/hatch_build.py
@@ -22,7 +22,7 @@ class CustomHook(BuildHookInterface):
         prefix = os.path.join(here, "data_kernelspec")
 
         with TemporaryDirectory() as td:
-            os.chmod(td, 0o755)  # Starts off as 700, not user readable
+            os.chmod(td, 0o755)  # noqa: S103 Starts off as 700, not user readable
             with open(os.path.join(td, "kernel.json"), "w") as f:
                 json.dump(kernel_json, f, sort_keys=True)
             print("Installing Jupyter kernel spec")

--- a/metakernel_python/hatch_build.py
+++ b/metakernel_python/hatch_build.py
@@ -22,7 +22,7 @@ class CustomHook(BuildHookInterface):
         prefix = os.path.join(here, "data_kernelspec")
 
         with TemporaryDirectory() as td:
-            os.chmod(td, 0o755)  # Starts off as 700, not user readable
+            os.chmod(td, 0o755)  # noqa: S103 Starts off as 700, not user readable
             with open(os.path.join(td, "kernel.json"), "w") as f:
                 json.dump(kernel_json, f, sort_keys=True)
             print("Installing Jupyter kernel spec")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,10 +128,20 @@ extend-select = [
   "B",      # flake8-bugbear
   "I",      # isort
   "RUF",    # Ruff-specific
+  "S",      # flake8-bandit (security)
   "UP",     # pyupgrade
 ]
-ignore = ["RUF012", "RUF005"]
+ignore = [
+  "RUF005",
+  "RUF012",
+  "S102",   # exec() is fundamental to a Python kernel/REPL
+  "S307",   # eval() is fundamental to a kernel/REPL system
+  "S310",   # URL open with user-provided URLs is intentional
+  "S603",   # subprocess with trusted internal input
+  "S604",   # shell= as a dict key is not a security issue (false positive)
+  "S607",   # partial executable path is intentional
+]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["UP031", "E402", "RUF012", "F841"]
+"tests/**" = ["UP031", "E402", "RUF012", "F841", "S101", "S108"]
 "metakernel/pexpect.py" = ["F401"]


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Enables the `S` (flake8-bandit) rule set in the ruff lint configuration to surface security-relevant patterns across the codebase.

## Changes

- Added `"S"` to `extend-select` in `[tool.ruff.lint]`
- Globally suppressed rules inherent to a kernel/REPL system: `S102` (exec), `S307` (eval), `S310` (URL open), `S603` (subprocess), `S604` (false positive on `shell=` dict key), `S607` (partial executable path)
- Added `S101` and `S108` to `tests/**` per-file-ignores (asserts and temp files are normal in tests)
- Added `# noqa` comments for intentional patterns in source: `S110`/`S112` (deliberate silent exception handling), `S101` (type-narrowing asserts), `S103` (intentional chmod modes)

## Backwards-incompatible changes

None

## Testing

`just pre-commit` passes cleanly.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6