### PR TITLE
Use pre-fixed jigsaw_v2 HTML and expand test coverage

### DIFF
--- a/metakernel/magics/jigsaw_magic.py
+++ b/metakernel/magics/jigsaw_magic.py
@@ -20,135 +20,6 @@ def download(url: str) -> str:
     return g.read().decode("utf-8")  # type: ignore[no-any-return]
 
 
-def _fix_cross_origin(html_text: str, language: str, saved_xml: str = "") -> str:
-    """Rewrite cross-origin window.parent accesses to use postMessage (#170).
-
-    Direct property access on a cross-origin (or null-origin sandboxed) parent
-    frame is blocked by modern browsers.  postMessage() is explicitly permitted
-    across any origin boundary, so we:
-
-    1. Remove the lines that expose Blockly/DOMParser on the parent window.
-    2. Replace the jigsaw_register_workspace() call with inline initialisation
-       that reads the workspace XML from a JS variable embedded in the HTML at
-       magic run time (avoids XHR, which also fails from a null-origin frame).
-    3. Replace button onclick handlers with postMessage calls via small helper
-       functions injected just before </body>.
-    4. Remove the stray ``window.parent.block = block`` assignment.
-    """
-    import json
-    import re
-
-    # 1. Remove lines that expose Blockly/DOMParser to the parent window.
-    html_text = html_text.replace(
-        "      // Make Blockly available to notebook:\n"
-        "      window.parent.Blockly = Blockly;\n"
-        "      window.parent.DOMParser = DOMParser;\n",
-        "",
-    )
-
-    # 2. Replace jigsaw_register_workspace with inline XML initialisation.
-    #    The saved XML (if any) is injected as window.__jigsaw_saved_xml__
-    #    in a <script> tag added to <head>, so no XHR is needed.
-    html_text = html_text.replace(
-        "      var xml_init = document.getElementById('workspace');\n"
-        '      window.parent.document.jigsaw_register_workspace("MYWORKSPACENAME", workspace, xml_init);',
-        "      var xml_init = document.getElementById('workspace');\n"
-        "      // Restore saved workspace XML embedded at magic run time (fixes #170).\n"
-        "      (function() {\n"
-        "        function applyXml(xml) {\n"
-        "          try {\n"
-        "            Blockly.Xml.domToWorkspace(workspace,\n"
-        "              xml || xml_init ||\n"
-        "              Blockly.Xml.textToDom('<xml id=\"workspace\"></xml>'));\n"
-        "          } catch(e) {}\n"
-        "        }\n"
-        "        try {\n"
-        "          var saved = window.__jigsaw_saved_xml__;\n"
-        "          if (saved) {\n"
-        "            applyXml(new DOMParser().parseFromString(saved, 'text/xml').documentElement);\n"
-        "          } else {\n"
-        "            applyXml(null);\n"
-        "          }\n"
-        "        } catch(e) { applyXml(null); }\n"
-        "      })();",
-    )
-
-    # Embed the saved XML as a JS variable in <head> so the init code above
-    # can read it without any network request.
-    xml_script = (
-        f"<script>window.__jigsaw_saved_xml__ = {json.dumps(saved_xml)};</script>\n"
-    )
-    html_text = html_text.replace("</head>", xml_script + "</head>")
-
-    # 3. Replace button onclick handlers with local helper calls.
-    #    Use regex so the actual Blockly language in the HTML (e.g. 'Java' for
-    #    Processing, 'Python' for Python) is preserved rather than requiring it
-    #    to match the %jigsaw LANGUAGE argument.
-    #    Replace insert (with trailing ', 1') before run (without) to avoid a
-    #    partial match on the run pattern.
-    html_text = re.sub(
-        r"window\.parent\.document\.jigsaw_generate\('MYWORKSPACENAME', '([^']+)', 1\)",
-        r"_jigsaw_insert(workspace, '\1', 'MYWORKSPACENAME')",
-        html_text,
-    )
-    html_text = re.sub(
-        r"window\.parent\.document\.jigsaw_generate\('MYWORKSPACENAME', '([^']+)'\)",
-        r"_jigsaw_run(workspace, '\1', 'MYWORKSPACENAME')",
-        html_text,
-    )
-    html_text = html_text.replace(
-        "window.parent.document.jigsaw_clear_output('MYWORKSPACENAME')",
-        "_jigsaw_clear('MYWORKSPACENAME')",
-    )
-
-    # 4. Remove stray window.parent property assignments (dead code in the HTML).
-    html_text = html_text.replace("window.parent.block = block;", "")
-
-    # 5. Inject helper functions before </body>.
-    #    Send to both window.parent and window.top so the message reaches the
-    #    listener regardless of whether Javascript(script) runs in a sandboxed
-    #    output-cell frame (window.parent) or the top-level page (window.top).
-    #    A msg_id lets the listener deduplicate if both deliveries arrive.
-    helper = (
-        "<script>\n"
-        "  // Use 4-space indentation for all Blockly code generators.\n"
-        "  (function() {\n"
-        "    var gens = ['Python', 'JavaScript', 'Java', 'Dart', 'Lua', 'PHP'];\n"
-        "    for (var i = 0; i < gens.length; i++) {\n"
-        "      if (Blockly[gens[i]]) Blockly[gens[i]].INDENT = '    ';\n"
-        "    }\n"
-        "  })();\n"
-        "  function _jigsaw_send(msg) {\n"
-        "    msg.msg_id = Math.random().toString(36).slice(2);\n"
-        "    try { window.parent.postMessage(msg, '*'); } catch(e) {}\n"
-        "    try {\n"
-        "      if (window.top !== window.parent) {\n"
-        "        window.top.postMessage(msg, '*');\n"
-        "      }\n"
-        "    } catch(e) {}\n"
-        "  }\n"
-        "  function _jigsaw_run(ws, lang, wf) {\n"
-        "    var code = Blockly[lang].workspaceToCode(ws);\n"
-        "    var xml  = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(ws));\n"
-        "    _jigsaw_send({type:'jigsaw', action:'execute',\n"
-        "      workspace_filename:wf, code:code, save_xml:xml});\n"
-        "  }\n"
-        "  function _jigsaw_insert(ws, lang, wf) {\n"
-        "    var code = Blockly[lang].workspaceToCode(ws);\n"
-        "    var xml  = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(ws));\n"
-        "    _jigsaw_send({type:'jigsaw', action:'insert',\n"
-        "      workspace_filename:wf, code:code, save_xml:xml});\n"
-        "  }\n"
-        "  function _jigsaw_clear(wf) {\n"
-        "    _jigsaw_send({type:'jigsaw', action:'clear', workspace_filename:wf});\n"
-        "  }\n"
-        "</script>\n"
-    )
-    html_text = html_text.replace("</body>", helper + "</body>")
-
-    return html_text
-
-
 class JigsawMagic(Magic):
     @option(
         "-w",
@@ -181,7 +52,9 @@ class JigsawMagic(Magic):
                 )
             )
         workspace_filename = workspace + ".xml"
-        html_text = download("https://calysto.github.io/jigsaw/" + language + ".html")
+        html_text = download(
+            "https://calysto.github.io/jigsaw_v2/" + language + ".html"
+        )
         html_filename = workspace + ".html"
         html_dir = os.path.dirname(html_filename)
         if html_dir:
@@ -194,8 +67,11 @@ class JigsawMagic(Magic):
                     saved_xml = f.read()
             except OSError:
                 pass
-        # Fix cross-origin issue before substituting the workspace placeholder.
-        html_text = _fix_cross_origin(html_text, language, saved_xml)
+        # Embed saved XML into the placeholder injected by the local server HTML.
+        html_text = html_text.replace(
+            'window.__jigsaw_saved_xml__ = "";',
+            f"window.__jigsaw_saved_xml__ = {_json.dumps(saved_xml)};",
+        )
         html_text = html_text.replace("MYWORKSPACENAME", workspace_filename)
         with open(html_filename, "w") as fp:
             fp.write(html_text)

--- a/tests/magics/test_jigsaw_magic.py
+++ b/tests/magics/test_jigsaw_magic.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 
 import pytest
 
@@ -10,46 +11,68 @@ from tests.utils import (
     has_network,
 )
 
+LANGUAGES = ["Processing", "Python", "Test"]
 
-@pytest.mark.skipif(not has_network(), reason="no network")
-def test_jigsaw_magic() -> None:
+skip_no_network = pytest.mark.skipif(not has_network(), reason="no network")
+
+
+@skip_no_network
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_jigsaw_magic(tmp_path: pytest.TempPathFactory, language: str) -> None:
     kernel = get_kernel(EvalKernel)
-    asyncio.run(kernel.do_execute("%jigsaw Processing --workspace workspace1"))
-    text = get_log_text(kernel)
-    assert os.path.isfile("workspace1.html"), "File does not exist: workspace1.html"
+    asyncio.run(
+        kernel.do_execute(f"%jigsaw {language} --workspace {tmp_path}/workspace1")
+    )
+    get_log_text(kernel)
+    assert os.path.isfile(f"{tmp_path}/workspace1.html")
 
 
-@pytest.mark.skipif(not has_network(), reason="no network")
-def test_jigsaw_magic_direct() -> None:
+@skip_no_network
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_jigsaw_magic_direct(tmp_path: pytest.TempPathFactory, language: str) -> None:
     """Test calling JigsawMagic.line_jigsaw directly with a workspace filename."""
     from metakernel.magics.jigsaw_magic import JigsawMagic
 
     kernel = get_kernel(EvalKernel)
     magic = JigsawMagic(kernel)
-    magic.line_jigsaw("Processing", workspace="workspace1")
-    assert os.path.isfile("workspace1.html"), "File does not exist: workspace1.html"
+    magic.line_jigsaw(language, workspace=str(tmp_path / "workspace1"))
+    assert os.path.isfile(f"{tmp_path}/workspace1.html")
 
 
-@pytest.mark.skipif(not has_network(), reason="no network")
-def test_jigsaw_magic_with_path() -> None:
+@skip_no_network
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_jigsaw_html_content(tmp_path: pytest.TempPathFactory, language: str) -> None:
+    """Generated HTML uses postMessage, has no window.parent violations, and embeds saved-XML placeholder."""
+    from metakernel.magics.jigsaw_magic import JigsawMagic
+
+    kernel = get_kernel(EvalKernel)
+    magic = JigsawMagic(kernel)
+    magic.line_jigsaw(language, workspace=str(tmp_path / "workspace1"))
+
+    with open(f"{tmp_path}/workspace1.html") as f:
+        html = f.read()
+
+    # postMessage helpers must be present.
+    assert "_jigsaw_send" in html
+    assert "_jigsaw_run" in html
+    assert "_jigsaw_insert" in html
+    assert "_jigsaw_clear" in html
+    assert "postMessage" in html
+
+    # No direct cross-origin property writes.
+    assert not re.search(r"window\.parent\.\w+\s*=", html), (
+        "Direct window.parent property assignment found"
+    )
+    assert "window.parent.document.jigsaw_" not in html
+
+    # Saved-XML placeholder must be present (magic fills it at runtime).
+    assert "window.__jigsaw_saved_xml__" in html
+
+
+@skip_no_network
+def test_jigsaw_magic_with_path(tmp_path: pytest.TempPathFactory) -> None:
     """Test that %jigsaw saves files in a subdirectory when path is given in workspace (issue #167)."""
     kernel = get_kernel(EvalKernel)
-    asyncio.run(
-        kernel.do_execute(
-            "%jigsaw Processing --workspace jigsaw_test_subdir/workspace1"
-        )
-    )
-    assert os.path.isfile("jigsaw_test_subdir/workspace1.html"), (
-        "File does not exist: jigsaw_test_subdir/workspace1.html"
-    )
-
-
-def teardown() -> None:
-    import shutil
-
-    for fname in ["workspace1.html"]:
-        try:
-            os.remove(fname)
-        except OSError:
-            pass
-    shutil.rmtree("jigsaw_test_subdir", ignore_errors=True)
+    workspace = tmp_path / "subdir" / "workspace1"
+    asyncio.run(kernel.do_execute(f"%jigsaw Processing --workspace {workspace}"))
+    assert os.path.isfile(f"{workspace}.html")

--- a/tests/magics/test_jigsaw_magic.py
+++ b/tests/magics/test_jigsaw_magic.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import re
+from pathlib import Path
 
 import pytest
 
@@ -18,7 +19,7 @@ skip_no_network = pytest.mark.skipif(not has_network(), reason="no network")
 
 @skip_no_network
 @pytest.mark.parametrize("language", LANGUAGES)
-def test_jigsaw_magic(tmp_path: pytest.TempPathFactory, language: str) -> None:
+def test_jigsaw_magic(tmp_path: Path, language: str) -> None:
     kernel = get_kernel(EvalKernel)
     asyncio.run(
         kernel.do_execute(f"%jigsaw {language} --workspace {tmp_path}/workspace1")
@@ -29,7 +30,7 @@ def test_jigsaw_magic(tmp_path: pytest.TempPathFactory, language: str) -> None:
 
 @skip_no_network
 @pytest.mark.parametrize("language", LANGUAGES)
-def test_jigsaw_magic_direct(tmp_path: pytest.TempPathFactory, language: str) -> None:
+def test_jigsaw_magic_direct(tmp_path: Path, language: str) -> None:
     """Test calling JigsawMagic.line_jigsaw directly with a workspace filename."""
     from metakernel.magics.jigsaw_magic import JigsawMagic
 
@@ -41,7 +42,7 @@ def test_jigsaw_magic_direct(tmp_path: pytest.TempPathFactory, language: str) ->
 
 @skip_no_network
 @pytest.mark.parametrize("language", LANGUAGES)
-def test_jigsaw_html_content(tmp_path: pytest.TempPathFactory, language: str) -> None:
+def test_jigsaw_html_content(tmp_path: Path, language: str) -> None:
     """Generated HTML uses postMessage, has no window.parent violations, and embeds saved-XML placeholder."""
     from metakernel.magics.jigsaw_magic import JigsawMagic
 
@@ -70,7 +71,7 @@ def test_jigsaw_html_content(tmp_path: pytest.TempPathFactory, language: str) ->
 
 
 @skip_no_network
-def test_jigsaw_magic_with_path(tmp_path: pytest.TempPathFactory) -> None:
+def test_jigsaw_magic_with_path(tmp_path: Path) -> None:
     """Test that %jigsaw saves files in a subdirectory when path is given in workspace (issue #167)."""
     kernel = get_kernel(EvalKernel)
     workspace = tmp_path / "subdir" / "workspace1"


### PR DESCRIPTION
## References
Follow up to #375

## Description

Moves the cross-origin postMessage fixes out of `jigsaw_magic.py` and into the upstream HTML source files (now served from `calysto.github.io/jigsaw_v2/`). The magic no longer needs to patch downloaded HTML at runtime — it only fills in the `window.__jigsaw_saved_xml__` placeholder that is already baked into the v2 files.

## Changes

- Remove `_fix_cross_origin()` function from `jigsaw_magic.py` (~127 lines)
- Update download URL from `jigsaw/` to `jigsaw_v2/`
- Replace `_fix_cross_origin()` call with a single targeted string replacement for the saved-XML placeholder
- Delete `scripts/reproduce_196.py` (referenced the now-removed function)
- Parametrize jigsaw tests across all three languages: `Processing`, `Python`, `Test`
- Add `test_jigsaw_html_content` to assert postMessage helpers are present and no `window.parent` property assignments remain
- Switch all test file output to pytest `tmp_path` (no files written to the repo directory)
- Remove manual `teardown()` function

## Backwards-incompatible changes

None

## Testing

`just test tests/magics/test_jigsaw_magic.py` — 10/10 tests pass across all three languages.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)