### PR TITLE
Add JupyterHub deployment docs and cross-origin regression tests (issue #196)

### DIFF
--- a/docs/jupyterhub.md
+++ b/docs/jupyterhub.md
@@ -1,0 +1,158 @@
+# JupyterHub Deployment
+
+This page describes how to deploy MetaKernel-based kernels on
+[JupyterHub](https://jupyterhub.readthedocs.io/) and how to configure a
+reverse proxy (Apache or nginx) in front of JupyterHub.
+
+## Installing a kernel for all users
+
+On a shared JupyterHub server you typically want to install the kernel
+system-wide so that every user can select it:
+
+```bash
+# as root or with sudo
+python -m my_kernel install --sys-prefix
+```
+
+If you run JupyterHub inside a conda environment, use `--sys-prefix` to
+install into that environment's prefix. The `--user` flag is appropriate
+for single-user testing but **will not** make the kernel visible to other
+JupyterHub users.
+
+## Kernel discovery
+
+JupyterHub spawns a separate single-user server for each user. The kernel
+spec (installed under a shared prefix) is found automatically as long as
+the `JUPYTER_PATH` environment variable includes the prefix's data
+directory. No additional configuration is usually needed.
+
+## Reverse proxy configuration
+
+JupyterHub must be reached through a single public URL (e.g.
+`https://hub.example.com/jupyter`). Both Apache and nginx need special
+settings to proxy WebSocket connections, which the Jupyter protocol relies
+on for kernel communication.
+
+### Apache (mod_proxy / mod_proxy_wstunnel)
+
+```apache
+<VirtualHost *:443>
+    ServerName hub.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/ssl/certs/hub.crt
+    SSLCertificateKeyFile /etc/ssl/private/hub.key
+
+    # Enable the required proxy modules:
+    #   LoadModule proxy_module          modules/mod_proxy.so
+    #   LoadModule proxy_http_module     modules/mod_proxy_http.so
+    #   LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+
+    ProxyPreserveHost On
+
+    # WebSocket upgrade (kernel channels, terminals)
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} websocket [NC]
+    RewriteRule /jupyter/(.*) ws://127.0.0.1:8000/jupyter/$1 [P,L]
+
+    # Standard HTTP
+    ProxyPass        /jupyter/ http://127.0.0.1:8000/jupyter/
+    ProxyPassReverse /jupyter/ http://127.0.0.1:8000/jupyter/
+
+    # Required headers
+    RequestHeader set X-Scheme https
+    RequestHeader set X-Forwarded-Proto https
+</VirtualHost>
+```
+
+Set the matching base URL in your `jupyterhub_config.py`:
+
+```python
+c.JupyterHub.base_url = '/jupyter/'
+```
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name hub.example.com;
+
+    ssl_certificate     /etc/ssl/certs/hub.crt;
+    ssl_certificate_key /etc/ssl/private/hub.key;
+
+    location /jupyter/ {
+        proxy_pass         http://127.0.0.1:8000;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+
+        # Increase timeouts for long-running kernels
+        proxy_read_timeout 86400;
+    }
+}
+```
+
+## Jigsaw magic under JupyterHub
+
+The `%jigsaw` magic embeds a Blockly visual editor in an IFrame. In a
+JupyterHub environment the IFrame is served from the user's file space
+(`/user/{name}/files/workspace.html`), which has a **different origin**
+from the notebook page. Modern browsers block direct `window.parent`
+property access across origins, causing a `SecurityError`.
+
+MetaKernel handles this automatically by:
+
+1. **Replacing `window.parent.*` property access with `postMessage`** — the
+   iframe sends structured messages to the parent page instead of accessing
+   its DOM directly.
+1. **Embedding saved workspace XML in the HTML** — instead of fetching the
+   `.xml` file via XHR (which is also blocked from a cross-origin or
+   sandboxed iframe), the XML is serialised into a JavaScript variable
+   inside the generated HTML file at magic-run time.
+1. **WebSocket kernel execution fallback** — when the classic
+   `IPython.notebook` or JupyterLab JS APIs are not reachable, the helper
+   falls back to discovering the kernel via the REST `/api/sessions`
+   endpoint and connects directly over WebSocket. The base URL is read
+   from the `jupyter-config-data` element injected by the server, so the
+   correct JupyterHub-prefixed path is used automatically.
+
+No special configuration is required — these fixes are applied every time
+`%jigsaw` is executed.
+
+### Known limitations
+
+- The `%jigsaw` magic writes the generated `.html` and `.xml` workspace
+  files to the **current working directory** of the kernel. On JupyterHub
+  this is typically the user's home directory, so the files are accessible
+  through the file browser.
+- Very restrictive Content Security Policies set by the proxy (e.g.
+  `frame-src 'self'`) may still prevent the IFrame from loading. If you
+  control the proxy, allow `frame-src` for the JupyterHub origin.
+
+## Troubleshooting
+
+**Kernel does not appear in the launcher**
+: Check that the kernel spec is installed under a prefix that is on
+`JUPYTER_PATH`. Run `jupyter kernelspec list` as the spawned user to
+verify.
+
+**`%jigsaw` shows a blank iframe / SecurityError in the browser console**
+: Make sure you are running a recent version of MetaKernel (≥ 0.30).
+Earlier versions wrote HTML that accessed `window.parent` directly, which
+is blocked across origins.
+
+**WebSocket connections fail through the proxy**
+: Ensure `mod_proxy_wstunnel` (Apache) or `proxy_http_version 1.1` +
+`Upgrade`/`Connection` headers (nginx) are configured. WebSocket
+upgrades require explicit proxy support.
+
+**404 on `/jupyter/` after setting `base_url`**
+: The trailing slash in `c.JupyterHub.base_url = '/jupyter/'` is required.
+The proxy `ProxyPass` / `location` block must use the same path prefix.

--- a/docs/jupyterhub.md
+++ b/docs/jupyterhub.md
@@ -144,7 +144,7 @@ No special configuration is required — these fixes are applied every time
 verify.
 
 **`%jigsaw` shows a blank iframe / SecurityError in the browser console**
-: Make sure you are running a recent version of MetaKernel (≥ 0.30).
+: Make sure you are running a recent version of MetaKernel (≥ 1.0).
 Earlier versions wrote HTML that accessed `window.parent` directly, which
 is blocked across origins.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,4 +43,5 @@ nav:
   - Creating a Kernel: new_kernel.md
   - Creating a Magic: new_magic.md
   - Magics Reference: magics.md
+  - JupyterHub Deployment: jupyterhub.md
   - API Reference: api.md

--- a/tests/magics/test_jigsaw_magic.py
+++ b/tests/magics/test_jigsaw_magic.py
@@ -44,6 +44,75 @@ def test_jigsaw_magic_with_path() -> None:
     )
 
 
+def _make_jigsaw_html(workspace_name: str = "MYWORKSPACENAME") -> str:
+    """Return a minimal jigsaw HTML snippet with all cross-origin patterns."""
+    return (
+        "<html><head></head><body>"
+        "<script>\n"
+        "      // Make Blockly available to notebook:\n"
+        "      window.parent.Blockly = Blockly;\n"
+        "      window.parent.DOMParser = DOMParser;\n"
+        "      var xml_init = document.getElementById('workspace');\n"
+        f'      window.parent.document.jigsaw_register_workspace("{workspace_name}", workspace, xml_init);\n'
+        f"window.parent.document.jigsaw_generate('{workspace_name}', 'Python');\n"
+        f"window.parent.document.jigsaw_generate('{workspace_name}', 'Python', 1);\n"
+        f"window.parent.document.jigsaw_clear_output('{workspace_name}');\n"
+        "window.parent.block = block;\n"
+        "</script>"
+        "</body></html>"
+    )
+
+
+def test_fix_cross_origin_jupyterhub(tmp_path: "os.PathLike[str]") -> None:
+    """_fix_cross_origin removes all direct window.parent property accesses.
+
+    Under JupyterHub / Apache reverse-proxy the jigsaw iframe is served from
+    a different origin (or as a null-origin sandboxed iframe), so any direct
+    ``window.parent.<property>`` access raises a SecurityError.  This test
+    verifies that ``_fix_cross_origin`` replaces every such pattern with
+    postMessage-based alternatives so that ``%jigsaw`` works in those
+    environments (issue #196).
+    """
+    from metakernel.magics.jigsaw_magic import _fix_cross_origin
+
+    html_in = _make_jigsaw_html()
+    html_out = _fix_cross_origin(html_in, "Python", saved_xml="")
+
+    # All direct cross-origin window.parent accesses must be gone.
+    assert "window.parent.Blockly" not in html_out
+    assert "window.parent.DOMParser" not in html_out
+    assert "window.parent.document.jigsaw_register_workspace" not in html_out
+    assert "window.parent.document.jigsaw_generate" not in html_out
+    assert "window.parent.document.jigsaw_clear_output" not in html_out
+    assert "window.parent.block = block" not in html_out
+
+    # postMessage helper infrastructure must be injected.
+    assert "postMessage" in html_out
+    assert "_jigsaw_send" in html_out
+    assert "_jigsaw_run" in html_out
+    assert "_jigsaw_insert" in html_out
+    assert "_jigsaw_clear" in html_out
+
+
+def test_fix_cross_origin_embeds_saved_xml() -> None:
+    """Saved workspace XML is embedded in the HTML, not fetched via XHR.
+
+    Under JupyterHub / reverse-proxy a sandboxed iframe cannot make XHR
+    requests back to the server to load the workspace file.  The fix embeds
+    the XML directly as a JS variable so no network request is needed
+    (issue #196).
+    """
+    from metakernel.magics.jigsaw_magic import _fix_cross_origin
+
+    saved_xml = '<xml id="workspace"><block type="controls_if"/></xml>'
+    html_in = _make_jigsaw_html() + ""  # fresh copy
+    html_out = _fix_cross_origin(html_in, "Python", saved_xml=saved_xml)
+
+    # The XML must appear as an embedded JS variable, not require an XHR.
+    assert "__jigsaw_saved_xml__" in html_out
+    assert "controls_if" in html_out  # actual XML content is present
+
+
 def teardown() -> None:
     import shutil
 


### PR DESCRIPTION
## References

Closes #196 in combination with #375 (the code fixes already merged in #375 + this PR together fully address the issue).

## Description

Adds a dedicated `docs/jupyterhub.md` page covering MetaKernel deployment on JupyterHub and behind an Apache or nginx reverse proxy. Also adds two unit tests that demonstrate the cross-origin (`window.parent`) bug reported in #196 and verify the fix introduced in #375 (`_fix_cross_origin`) handles every affected pattern.

## Changes

- `docs/jupyterhub.md` — new page covering:
  - System-wide kernel installation for JupyterHub
  - Apache (`mod_proxy_wstunnel`) and nginx reverse-proxy configuration with WebSocket support
  - Explanation of the Jigsaw CORS issue and how MetaKernel resolves it (postMessage, embedded XML, WebSocket fallback with base-URL handling)
  - Known limitations and troubleshooting
- `mkdocs.yml` — adds the new page to the nav
- `tests/magics/test_jigsaw_magic.py` — two new offline tests:
  - `test_fix_cross_origin_jupyterhub` — asserts all `window.parent.*` accesses are replaced by postMessage helpers (issue #196)
  - `test_fix_cross_origin_embeds_saved_xml` — asserts saved workspace XML is embedded as a JS variable instead of requiring an XHR

## Backwards-incompatible changes

None

## Testing

`just test tests/magics/test_jigsaw_magic.py` — all 5 tests pass, including the two new ones which run offline (no network required).

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)