### PR TITLE
Fix test_magics Windows CI failure: use %shell instead of %%shell

### DIFF
--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -73,7 +73,10 @@ def test_magics() -> None:
         assert magic in kernel.cell_magics
 
     with tempfile.NamedTemporaryFile() as ntf:
-        kernel.get_magic("%%shell ls %s" % ntf.name)
+        # Use %shell (line magic) so the command is passed as args to line_shell(),
+        # not as cell body to cell_shell(). %%shell with the command on the first
+        # line sets self.code="" so the command is never actually executed.
+        kernel.get_magic("%shell ls %s" % ntf.name)
         log_text = get_log_text(kernel)
         # Windows may give 8.3 short paths (RUNNER~1) vs long paths in shell output
         assert os.path.basename(ntf.name) in log_text

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -76,7 +76,7 @@ def test_magics() -> None:
         # Use %shell (line magic) so the command is passed as args to line_shell(),
         # not as cell body to cell_shell(). %%shell with the command on the first
         # line sets self.code="" so the command is never actually executed.
-        kernel.get_magic("%shell ls %s" % ntf.name)
+        kernel.get_magic(f"%shell ls {ntf.name}")
         log_text = get_log_text(kernel)
         # Windows may give 8.3 short paths (RUNNER~1) vs long paths in shell output
         assert os.path.basename(ntf.name) in log_text


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Fixes a Windows CI failure in `test_magics`:

```
FAILED tests/test_metakernel.py::test_magics - AssertionError: assert 'tmp581olf8l' in ''
```

`%%shell ls <path>` uses cell magic syntax, where the command on the first line is parsed as `args` rather than the cell body (`self.code`). Since `cell_shell()` executes `self.code`, the command was never actually run — `self.code` was always `""`.

On Linux this coincidentally passed because the `TypeError` raised by `call_magic`'s argument mismatch produced a logged error message that contained the file path in its `args:` dump. On Windows that error message does not appear in `log_text`, so the assertion `assert os.path.basename(ntf.name) in log_text` failed against an empty string.

## Changes

- Replace `"%%shell ls %s"` with `"%shell ls %s"` in `test_magics`. Using the line magic `%shell` properly calls `line_shell("ls", path)`, which executes the command in the shell and streams its output through `kernel.Print` → `log.debug(...)` → the `StringIO` handler that `get_log_text()` reads.

## Backwards-incompatible changes

None

## Testing

Existing test suite. The change makes the test correctly exercise shell execution rather than relying on an error message side-effect.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)