### PR TITLE
Add a workflow to update pre-commit versions and improve validate-pyproject

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,28 @@
+# .github/workflows/pre-commit-autoupdate.yml
+name: Pre-commit autoupdate
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am
+
+permissions:
+  pull-requests: write
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+      - run: pip install pre-commit
+      - run: pre-commit autoupdate
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
+        with:
+          commit-message: 'chore: pre-commit autoupdate'
+          title: 'chore: pre-commit autoupdate'
+          branch: pre-commit-autoupdate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,8 @@ repos:
     rev: v0.25
     hooks:
       - id: validate-pyproject
+        # Optional extra validations from SchemaStore:
+        additional_dependencies: ["validate-pyproject-schema-store[all]"]
 
   - repo: https://github.com/crate-ci/typos
     rev: "v1.42.0"


### PR DESCRIPTION

<!--
Thanks for contributing to MetaKernel!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/calysto/metakernel/blob/master/CONTRIBUTING.md
-->

## References

N/A

## Description
Add a workflow to update pre-commit rev versions on a weekly basis with a PR.
Use the extra SchemaStore validations for `validate-pyproject`.

## Changes

Add new workflow, update the `validate-pyproject` pre-commit hook.

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [ ] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None
