### PR TITLE
Fix release action by installing uv

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -42,6 +42,10 @@ runs:
         fetch-depth: 0
         persist-credentials: false
 
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      with:
+        enable-cache: true
+
     - uses: actions/create-github-app-token@v2
       id: app-token
       with:


### PR DESCRIPTION
<!--
Thanks for contributing to MetaKernel!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/calysto/metakernel/blob/master/CONTRIBUTING.md
-->

## References

<!-- issue numbers -->
#395 

## Description

<!-- describe this PR -->
Fixes the problem of a missing `uv` executable in the release action.

## Changes

Installs `uv` before using the `uv version` command.

<!-- list key changes -->

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [ ] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None
