### PR TITLE
Refine release workflow: add build-package job and simplify changelog template

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -80,7 +80,7 @@ runs:
         token: ${{ steps.app-token.outputs.token }}
         configurationJson: |
           {
-            "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+            "template": "#{{CHANGELOG}}\n",
             "categories": [
               {
                   "title": "## Enhancements Made",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,26 @@ on:
     - cron: "0 9 * * *"
 
 jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+        with:
+          attest-build-provenance-github: 'true'
+
   release:
+    needs: [build-package]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -41,11 +60,11 @@ jobs:
         id-token: write
         attestations: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Download packages built by build-and-inspect-python-package
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
       with:
-        persist-credentials: false
-
-    - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+        name: Packages
+        path: dist
 
     - name: Upload package to Test PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Refinements to the release workflow: separates package building into a dedicated job with provenance attestation, downloads pre-built packages in the release job, and simplifies the changelog template.

## Changes

- Add `build-package` job using `hynek/build-and-inspect-python-package` with GitHub build provenance attestation
- Make `publish` job depend on `build-package` and download pre-built packages from artifacts instead of rebuilding
- Simplify changelog template to remove the uncategorized section

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)