### PR TITLE
Add skip-existing to Test PyPI upload when dry_run is true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: ${{ inputs.dry_run == 'true' }}
 
     - name: Upload package to PyPI
       if: ${{ inputs.dry_run != 'true' }}


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

When `dry_run` is `true`, the Test PyPI upload now uses `skip-existing: true` to avoid failures if the version has already been uploaded.

## Changes

- Add `skip-existing: ${{ inputs.dry_run == 'true' }}` to the Test PyPI publish step in `release.yml`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)