### PR TITLE
Add verbose output to Test PyPI upload in dry_run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: ${{ inputs.dry_run == 'true' }}
 
     - name: Upload package to PyPI
       if: ${{ inputs.dry_run != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: ${{ inputs.dry_run == 'true' }}
+        verbose: ${{ inputs.dry_run == 'true' }}
 
     - name: Upload package to PyPI
       if: ${{ inputs.dry_run != 'true' }}


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Adds `verbose: true` to the Test PyPI upload step when `dry_run` is enabled, to make it easier to debug dry-run release issues.

## Changes

- Set `verbose` to `true` on the `pypa/gh-action-pypi-publish` Test PyPI step when `dry_run` is `true`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (claude-sonnet-4-6)