### PR TITLE
Fix release workflow: correct PyPI publish input name and add step summary

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -209,4 +209,5 @@ runs:
         else
           git push origin "HEAD:$REF"
         fi
+        echo "\n\n## Post version: ${VERSION}" >> $GITHUB_STEP_SUMMARY
         echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload package to Test PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
         skip-existing: ${{ inputs.dry_run }}
         verbose: ${{ inputs.dry_run }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,12 +69,11 @@ jobs:
     - name: Upload package to Test PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: ${{ inputs.dry_run == 'true' }}
-        verbose: ${{ inputs.dry_run == 'true' }}
+        repository_url: https://test.pypi.org/legacy/
+        skip-existing: ${{ inputs.dry_run }}
+        verbose: ${{ inputs.dry_run }}
 
     - name: Upload package to PyPI
-      if: ${{ inputs.dry_run != 'true' }}
+      if: ${{ !inputs.dry_run }}
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-      with:
-        repository-url: https://test.pypi.org/legacy/
+


### PR DESCRIPTION
## References

Follows #404, #405

## Description

Two small fixes to the release workflow that weren't included in the recent series of publish workflow fixes.

## Changes

- Fix \`repository_url\` → \`repository-url\` input name in \`pypa/gh-action-pypi-publish\` (the action uses hyphenated input names; \`repository_url\` is silently ignored)
- Add \`## Post version: \${VERSION}\` line to the GitHub Actions step summary after the post-version commit in \`action.yml\`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)