### PR TITLE
Skip dev version bump for pre-release versions

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -207,6 +207,7 @@ runs:
 
     - name: Bump to dev version
       shell: bash
+      if: ${{ !contains(env.VERSION, 'rc') && !contains(env.VERSION, 'beta') && !contains(env.VERSION, 'alpha') }}
       run: |
         echo "::group::Commands"
         uv version --bump patch --bump dev --frozen
@@ -215,6 +216,7 @@ runs:
 
     - name: Commit dev version bump
       shell: bash
+      if: ${{ !contains(env.VERSION, 'rc') && !contains(env.VERSION, 'beta') && !contains(env.VERSION, 'alpha') }}
       run: |
         echo "::group::Commands"
         git add pyproject.toml


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

When releasing an `rc`, `beta`, or `alpha` version, the release workflow was incorrectly bumping back to a dev version afterward. Pre-release versions should not trigger a dev version bump — only full releases should.

## Changes

- Added `if` conditions to the "Bump to dev version" and "Commit dev version bump" steps in `.github/actions/release/action.yml` to skip them when the released version contains `rc`, `beta`, or `alpha`.

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)