### PR TITLE
Disable attestations for PyPI publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,5 @@ jobs:
     - name: Upload package to PyPI
       if: ${{ !inputs.dry_run }}
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      with:
+        attestations: false


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Adds `attestations: false` to the `pypa/gh-action-pypi-publish` step for the final PyPI upload. The action requires this to be explicitly set when not using Sigstore attestations.

## Changes

- Set `attestations: false` on the Upload package to PyPI step in `.github/workflows/release.yml`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6