### PR TITLE
Release tooling: bump to 1.0.0rc4, improve version validation and bump_dev script

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -4,7 +4,8 @@ description: Bumps version, updates changelog, creates GitHub release
 inputs:
   version:
     required: true
-    description: "Version to release (e.g. 1.0.0, minor, patch, rc, dev)"
+    # See https://python-poetry.org/docs/cli/#version for a description of version types.
+    description: "Version to release: a version number (e.g. 1.0.0rc4) or one of: patch, minor, major, prepatch, preminor, premajor, prerelease"
   dry_run:
     required: false
     default: "false"
@@ -29,6 +30,21 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate version input
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        VALID_BUMPS="patch minor major prepatch preminor premajor prerelease"
+        if echo "$VALID_BUMPS" | grep -qw "$VERSION"; then
+          echo "Version bump type: $VERSION"
+        elif echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
+          echo "Version string: $VERSION"
+        else
+          echo "Error: '$VERSION' is not a valid version. Must be a version number (e.g. 1.0.0rc4) or one of: $VALID_BUMPS"
+          exit 1
+        fi
+
     - name: Set environment variables and bash defaults
       shell: bash
       env:

--- a/.github/actions/release/bump_dev.py
+++ b/.github/actions/release/bump_dev.py
@@ -1,30 +1,38 @@
 #!/usr/bin/env python3
 """
-Transform a version string to a .dev version:
-  - "1.2.3"           -> "1.2.3.dev0"
-  - "1.2.3rc1"        -> "1.2.3.dev0"
-  - "1.2.3beta2"      -> "1.2.3.dev0"
-  - "1.2.3alpha1"     -> "1.2.3.dev0"
-  - "1.2.3.dev4"      -> "1.2.3.dev5"  (incremented)
+Transform a version string to the next .dev version:
+  - "1.2.3"           -> "1.2.4.dev0"  (patch bumped)
+  - "1.2.3.dev4"      -> no change (already a dev version)
+  - "1.2.3rc1"        -> no change (has pre-release suffix)
+  - "1.2.3beta2"      -> no change (has pre-release suffix)
+  - "1.2.3alpha1"     -> no change (has pre-release suffix)
 """
 
 import re
 import sys
 
 
+def has_suffix(version: str) -> bool:
+    """Return True if the version has any pre-release or dev suffix."""
+    return bool(
+        re.search(
+            r"(\.dev\d*|rc\d*|alpha\d*|beta\d*|a\d+|b\d+)", version, flags=re.IGNORECASE
+        )
+    )
+
+
 def transform_version(version: str) -> str:
-    # If already has .dev, increment the dev number
-    m = re.match(r"^(.+\.dev)(\d+)$", version)
+    # If version has any suffix (dev, rc, alpha, beta, etc.), do not bump
+    if has_suffix(version):
+        return version
+
+    # Bump the patch segment, then append .dev0
+    m = re.match(r"^(\d+\.\d+\.)(\d+)$", version)
     if m:
-        return f"{m.group(1)}{int(m.group(2)) + 1}"
+        return f"{m.group(1)}{int(m.group(2)) + 1}.dev0"
 
-    # Strip pre-release suffixes: rc, beta, alpha (and any trailing digits)
-    cleaned = re.sub(r"(rc|beta|alpha)\w*$", "", version, flags=re.IGNORECASE)
-
-    # Remove any trailing dot or separator left behind
-    cleaned = cleaned.rstrip(".-_")
-
-    return f"{cleaned}.dev0"
+    # Fallback: just append .dev0 if version doesn't match expected format
+    return f"{version}.dev0"
 
 
 if __name__ == "__main__":

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 1.0.0, patch, minor, rc, dev)"
+        # See https://python-poetry.org/docs/cli/#version for a description of version types.
+        description: "Version to release: a version number (e.g. 1.0.0rc4) or one of: patch, minor, major, prepatch, preminor, premajor, prerelease"
         required: true
         type: string
       dry_run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pexpect >=4.9.0",
     "jedi >=0.19.0",
 ]
-version = "1.0.2a0"
+version = "1.0.0rc4"
 readme = "README.md"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## References

#411 

<!-- issue numbers -->

## Description

Updates release tooling ahead of the 1.0.0 release cycle. Sets the version to `1.0.0rc4`, improves `bump_dev.py` to handle pre-release and dev versions correctly, and adds input validation to the release action with clearer documentation of accepted version formats.

## Changes

- Set version to `1.0.0rc4`
- Update `bump_dev.py`: skip bumping if version has any suffix (dev, rc, alpha, beta, a, b); bump patch for clean versions (`1.2.3` → `1.2.4.dev0`)
- Update release workflow and action `version` input description to enumerate valid poetry bump types (`patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`) and version strings (e.g. `1.0.0rc4`)
- Add link to https://python-poetry.org/docs/cli/#version in workflow/action comments
- Add validation step in release action that rejects unrecognized version inputs

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)