### PR TITLE
Fix cron workflows to skip forks and fix pre-commit permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   analyze:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -12,6 +12,7 @@ jobs:
   autoupdate:
     if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -5,16 +5,19 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9am
 
-permissions:
-  pull-requests: write
-
 jobs:
   autoupdate:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v2
+        id: app-token
         with:
-          persist-credentials: false
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -23,6 +26,7 @@ jobs:
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: pre-commit autoupdate'
           title: 'chore: pre-commit autoupdate'
           branch: pre-commit-autoupdate

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9am
 
+permissions:
+  contents: read
+
 jobs:
   autoupdate:
     if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   release:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'
     name: Build and Inspect Package
     runs-on: ubuntu-latest
     outputs:
@@ -156,4 +157,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
+          allowed-skips: test_release
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## References

N/A

## Description

Prevent scheduled (cron) workflow runs from executing on forked repositories, and fix the pre-commit autoupdate workflow's push permissions.

## Changes

- Add `if: github.event_name != 'schedule' || github.repository == 'Calysto/metakernel'` guard to all cron-triggered jobs across four workflows (tests, release, codeql, pre-commit-autoupdate)
- Fix pre-commit autoupdate workflow to use a GitHub App token for checkout and PR creation, resolving 403 permission errors on push
- Allow `test_release` job to be skipped in the `tests_check` alls-green gate

## Backwards-incompatible changes

None

## Testing

N/A — CI workflow changes only

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (claude-opus-4-6)