### PR TITLE
Add changelog_body input to release workflow and document release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      changelog_body:
+        description: "Custom release notes body (supports \\n for newlines)"
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "0 9 * * *"
 
@@ -35,6 +40,7 @@ jobs:
         with:
           version: ${{ github.event_name == 'schedule' && '10.10.10.10' || inputs.version }}
           dry_run: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run }}
+          changelog_body: ${{ inputs.changelog_body }}
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           ref: ${{ github.ref_name }}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,52 @@
 
 - Daniel Mendler @minad
 - Thomas Kluyver @takluyver
+
+# Release Process
+
+Releases are handled by the `release.yml` GitHub Actions workflow, triggered manually via `workflow_dispatch`.
+
+The `version` input accepts a version number (e.g. `1.0.0rc4`) or one of: `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`.
+
+## Using the GitHub UI
+
+1. Go to **Actions > Release** in the repository.
+1. Click **Run workflow**.
+1. Fill in the **version** field (e.g. `patch`, `minor`, `1.0.0`).
+1. Optionally fill in the **changelog_body** field with custom release notes. Use `\n` for newlines since the GitHub web UI input is single-line.
+1. Optionally check **Dry run** to test without publishing.
+1. Click **Run workflow**.
+
+## Using the CLI
+
+### Basic release
+
+```bash
+gh workflow run release.yml -f version=patch
+```
+
+### Release with custom changelog
+
+You can provide a custom changelog body using the `changelog_body` input:
+
+```bash
+gh workflow run release.yml \
+  -f version=patch \
+  -f changelog_body="## Highlights
+
+MetaKernel 1.0 is a major release.
+
+## New Features
+
+- DisplayData() for raw MIME bundle display (#211)"
+```
+
+### Dry run
+
+To test the release process without publishing:
+
+```bash
+gh workflow run release.yml -f version=patch -f dry_run=true
+```
+
+A dry run creates a draft release then deletes it, and does not push changes or publish to PyPI.


### PR DESCRIPTION
## References

N/A

## Description

Add support for providing custom release notes when triggering the release workflow, and document the full release process in CONTRIBUTORS.md.

## Changes

- Add `changelog_body` workflow input to `release.yml` and pass it through to the release action
- Add "Release Process" section to `CONTRIBUTORS.md` with instructions for both the GitHub UI and CLI workflows (including basic release, custom changelog, and dry run examples)

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (claude-opus-4-6)