### PR TITLE
Fix dry_run handling in publish job for scheduled runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       contents: write
     outputs:
       tag: ${{ steps.release.outputs.tag }}
+      dry_run: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,7 +64,7 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
   publish:
-    needs: [build-package]
+    needs: [release, build-package]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -80,11 +81,11 @@ jobs:
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
-        skip-existing: ${{ inputs.dry_run }}
-        verbose: ${{ inputs.dry_run }}
+        skip-existing: ${{ needs.release.outputs.dry_run }}
+        verbose: ${{ needs.release.outputs.dry_run }}
 
     - name: Upload package to PyPI
-      if: ${{ !inputs.dry_run }}
+      if: ${{ !needs.release.outputs.dry_run }}
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         attestations: false


### PR DESCRIPTION
## References

Relates to https://github.com/Calysto/metakernel/actions/runs/23481934503

## Description

The `publish` job used `inputs.dry_run` directly, which is undefined (empty string) for `schedule` events. This caused the publish job to treat dry runs as real publishes on scheduled runs.

## Changes

- Expose effective `dry_run` as an output of the `release` job using the same ternary logic already used for the release step
- Add `release` to `publish`'s `needs` so the output is accessible
- Replace all three `inputs.dry_run` references in `publish` with `needs.release.outputs.dry_run`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6