### PR TITLE
Fix sdist test collection failure for dragon.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 import asyncio
 import sys
 
+# Exclude logo-generation scripts that require optional Graphics/Myro packages
+collect_ignore_glob = ["metakernel/images/*.py"]
+
 if sys.platform == "win32":
     if sys.version_info >= (3, 14):
         asyncio.set_event_loop(asyncio.SelectorEventLoop())

--- a/poetry.lock
+++ b/poetry.lock
@@ -949,6 +949,7 @@ python-versions = ">=3.10"
 groups = ["docs"]
 files = [
     {file = "griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f"},
+    {file = "griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ipython = {version = ">=9.0"}
 minversion = "9.0"
 addopts= "-raXs  --durations 10 --color=yes --doctest-modules"
 testpaths = ["tests"]
+norecursedirs = ["images"]
 strict = true
 log_level = "INFO"
 timeout = 300


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

`metakernel/images/dragon.py` is a logo-generation script that imports optional `Graphics` and `Myro` packages at the top level. During the sdist test, pytest was collecting it as a module (due to `--doctest-modules`), failing immediately with `ImportError: No module named 'Graphics'` and interrupting the entire test run.

## Changes

- Added `collect_ignore_glob = ["metakernel/images/*.py"]` to `conftest.py` to exclude logo-generation scripts from pytest collection

## Backwards-incompatible changes

None

## Testing

The sdist test was failing with `Interrupted: 1 error during collection`. This change prevents collection of `dragon.py`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)