### PR TITLE
Set PYTHON_BASIC_REPL="1" for two new test

### DIFF
--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -136,6 +136,7 @@ class REPLWrapTestCase(unittest.TestCase):
             sys.executable,
             ">>> ",
             "import sys; sys.ps1={0!r}; sys.ps2={1!r}",
+            extra_env=dict(PYTHON_BASIC_REPL="1"),
         )
         res = p.run_command("1+1")
         assert res.strip() == "2"
@@ -149,6 +150,7 @@ class REPLWrapTestCase(unittest.TestCase):
             ">>> ",
             "import sys; sys.ps1={0!r}; sys.ps2={1!r}",
             args=["-i", "-c", "x=4+7"],
+            extra_env=dict(PYTHON_BASIC_REPL="1"),
         )
         res = p.run_command("x-11")
         assert res.strip() == "0"


### PR DESCRIPTION
## Description

This PR fixes two test failures when python uses pyrepl (the default in Python 3.13 and later if the terminal has sufficient capabilites for it to be used.

ValueError: Stdin Requested but not stdin handler available

.../metakernel/replwrap.py:151: ValueError

## Changes

Set PYTHON_BASIC_REPL="1" for two new test

## Backwards-incompatible changes

None

## Testing

Tests succeed with the proposed change.

## AI usage

**AI tools and models used**: None
