### PR TITLE
fix: extend cursor_start fix to magic get_completions (issue #432 follow-up)

### DIFF
--- a/metakernel/_metakernel.py
+++ b/metakernel/_metakernel.py
@@ -687,6 +687,13 @@ class MetaKernel(Kernel):
                 )
                 matches = new_list
 
+        # Extend the path-completion fix (#432) to magic get_completions: when the
+        # cursor sits after a non-identifier character (e.g. `--`, `-`) the id_regex
+        # again matches empty string so cursor_start is 0.  Completions should be
+        # appended at the cursor, not used to replace the entire line.
+        if not info["obj"] and matches:
+            content["cursor_start"] = content["cursor_end"]
+
         content["matches"] = sorted(matches)
 
         return content

--- a/tests/test_metakernel.py
+++ b/tests/test_metakernel.py
@@ -10,7 +10,7 @@ import pytest
 import zmq
 from traitlets.config import LoggingConfigurable
 
-from metakernel import ExceptionWrapper, MetaKernel
+from metakernel import ExceptionWrapper, Magic, MetaKernel
 from tests.utils import (
     EvalKernel,
     clear_log_text,
@@ -178,6 +178,35 @@ def test_path_complete_trailing_dash() -> None:
     comp = asyncio.run(kernel.do_complete(text, len(text)))
     # Even with no matches, cursor_start must not be 0 when there is a path prefix
     assert comp["cursor_start"] != 0 or comp["matches"] == [], comp
+
+
+def test_magic_complete_trailing_dash() -> None:
+    """Cursor after '--' in magic args must not replace the whole line (issue #432).
+
+    When a magic's get_completions returns matches and the cursor sits after a
+    non-identifier character such as '--', cursor_start must equal cursor_end so
+    that completions are appended at the cursor rather than replacing from position 0.
+    """
+
+    class OptionMagic(Magic):
+        """A magic that offers --opt1 and --opt2 as completions."""
+
+        def line_option_magic(self, arg: str = "") -> None:
+            """A magic with option completions."""
+
+        def get_completions(self, info: dict[str, Any]) -> list[str]:
+            options = ["opt1", "opt2"]
+            return [o for o in options if o.startswith(info["obj"])]
+
+    kernel = get_kernel()
+    kernel.register_magics(OptionMagic)
+
+    # Cursor after '--': obj is empty, magic get_completions returns matches.
+    # cursor_start must equal cursor_end (append at cursor, not replace from 0).
+    text = "%option_magic --"
+    comp = asyncio.run(kernel.do_complete(text, len(text)))
+    assert comp["cursor_start"] == comp["cursor_end"] == len(text), comp
+    assert comp["matches"] == ["opt1", "opt2"], comp
 
 
 def test_history() -> None:


### PR DESCRIPTION
## References

closes #432 (follow-up to #433)

## Description

The v1.0.3 fix in #433 corrected `cursor_start` for path completions when the cursor sits after a non-identifier character (e.g. `/`, `-`). However, when a magic's `get_completions` returns matches in the same situation (e.g. cursor after `--`), `cursor_start` was still left at 0, causing the Jupyter client to erase and replace the entire input line.

## Changes

- **`metakernel/_metakernel.py`**: At the end of `do_complete`, after all matches are collected, apply the same fix: when `info["obj"]` is empty and there are matches, set `cursor_start = cursor_end` so completions are appended at the cursor rather than replacing from position 0.
- **`tests/test_metakernel.py`**: Add `test_magic_complete_trailing_dash` — registers a custom magic with `get_completions` returning options, and asserts that for `%option_magic --`, `cursor_start == cursor_end`.

## Backwards-incompatible changes

None

## Testing

- `just test tests/test_metakernel.py` — all 93 tests pass including the new regression test
- `just typing` — no issues
- `just pre-commit` — all hooks pass

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)