### PR TITLE
Ignore DeprecationWarning from Python 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ filterwarnings= [
   "module:'setParseAction' deprecated - use 'set_parse_action':DeprecationWarning",
   # This is resolved in newer versions of Jupyter Core that removed the warning.
   "module:Jupyter is migrating its paths:DeprecationWarning",
+  # Warning from Python 3.15 (/usr/lib64/python3.15/pty.py)
+  "module:This process \\(pid=.*\\) is multi-threaded, use of forkpty\\(\\) may lead to deadlocks in the child:DeprecationWarning:pty",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## References

https://bugzilla.redhat.com/show_bug.cgi?id=2458668

## Description

This PR adds a new DeprecationWarning from Python 3.15 to the pytest ignore list.

## Changes

Add new line to the pytest section in pyproject.toml

## Backwards-incompatible changes

None

## Testing

Tested with python 3.15.0-alpha8

## AI usage

- [ ] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None
