### PR TITLE
fix: update nbviewer URL from ipython.org to jupyter.org

### DIFF
--- a/.markdown_link_config.json
+++ b/.markdown_link_config.json
@@ -10,7 +10,7 @@
             "pattern": "^http://host"
         },
         {
-            "pattern": "^http://nbviewer.ipython.org/"
+            "pattern": "^https://nbviewer.jupyter.org/"
         },
         {
             "pattern": "^http://some/file/from/"

--- a/examples/Calysto Processing.ipynb
+++ b/examples/Calysto Processing.ipynb
@@ -3,24 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Calysto Processing\n",
-    "\n",
-    "This notebook shows Calysto Processing, a MetaKernel-based Jupyter language.\n",
-    "\n",
-    "To see this notebook with included Javascript parts, please use this URL:\n",
-    "\n",
-    "http://nbviewer.ipython.org/github/Calysto/metakernel/blob/main/examples/Calysto%20Processing.ipynb\n",
-    "\n",
-    "To run Calysto Processing yourself, you will need:\n",
-    "\n",
-    "* IPython/Jupyter\n",
-    "* MetaKernel\n",
-    "* Calysto\n",
-    "* Calysto Processing\n",
-    "\n",
-    "You can run any Processing sketch as a cell in a notebook:"
-   ]
+   "source": "# Calysto Processing\n\nThis notebook shows Calysto Processing, a MetaKernel-based Jupyter language.\n\nTo see this notebook with included Javascript parts, please use this URL:\n\nhttps://nbviewer.jupyter.org/github/Calysto/metakernel/blob/main/examples/Calysto%20Processing.ipynb\n\nTo run Calysto Processing yourself, you will need:\n\n* IPython/Jupyter\n* MetaKernel\n* Calysto\n* Calysto Processing\n\nYou can run any Processing sketch as a cell in a notebook:"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

The nbviewer service moved from `nbviewer.ipython.org` to `nbviewer.jupyter.org`. This PR updates the stale URL in the example notebook and the markdown link config to reflect the current address.

## Changes

- Update `.markdown_link_config.json` ignore pattern from `http://nbviewer.ipython.org/` to `https://nbviewer.jupyter.org/`
- Update the nbviewer link in `examples/Calysto Processing.ipynb` to use the current URL

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6