### PR TITLE
fix: use https for nbviewer link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ c.OctaveKernel.plot_settings = dict(backend='qt')
 # Documentation
 
 Example notebooks can be viewed
-[here](http://nbviewer.jupyter.org/github/Calysto/metakernel/tree/main/examples/).
+[here](https://nbviewer.jupyter.org/github/Calysto/metakernel/tree/main/examples/).
 
 Documentation is available
 [online](http://Calysto.github.io/metakernel/). Magics have interactive


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Updates the nbviewer link in README.md to use `https` instead of `http`.

## Changes

- Changed `http://nbviewer.jupyter.org/...` to `https://nbviewer.jupyter.org/...`

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None