### PR TITLE
ci: use calysto/maintainer_tools build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
-        with:
-          include-free-threaded: "true"
+      - uses: calysto/maintainer_tools/actions/build@v1
 
   publish:
     needs: [release, build-package]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,13 @@ jobs:
     name: Build and Inspect Package
     runs-on: ubuntu-latest
     outputs:
-      supported_python_classifiers_json_array: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+      supported_python_classifiers_json_array: ${{ steps.baipp.outputs.python-versions }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df  # v2.18.0
+      - uses: calysto/maintainer_tools/actions/build@v1
         id: baipp
-        with:
-          include-free-threaded: "true"
 
   test:
     name: Test (Python ${{ matrix.python-version }})


### PR DESCRIPTION
<!--
Thanks for contributing to MetaKernel!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/calysto/metakernel/blob/master/CONTRIBUTING.md
-->

## References

None

## Description

Replaces the direct `hynek/build-and-inspect-python-package` step in `tests.yml` and `release.yml` with the new `calysto/maintainer_tools/actions/build@v1` composite action, which wraps the same underlying action.

## Changes

- `tests.yml`: use `calysto/maintainer_tools/actions/build@v1` in the `build` job; updated the `supported_python_classifiers_json_array` output reference to the action's new `python-versions` output.
- `release.yml`: use `calysto/maintainer_tools/actions/build@v1` in the `build-package` job.

## Backwards-incompatible changes

None

## Testing

Verified `just typing` and `just pre-commit` pass locally. Confirmed the `calysto/maintainer_tools` `v1` tag includes the new `build` action.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code