### PR TITLE
Standardize justfile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ just run-notebooks     # execute example notebooks
 just docs              # build MkDocs HTML docs
 just help              # regenerate magics/README.md from docstrings
 just typing            # run mypy type checks
-just lint              # run ruff linter
+just lint              # run all pre-commit hooks
+just lint-all          # also run manual-stage hooks (markdown-link-check)
 just clean             # remove build artifacts
 ```
 
@@ -65,7 +66,7 @@ poetry install --with test
 This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting,
 enforced via pre-commit hooks. The hooks are installed automatically by `just install`.
 
-Lint manually with `just lint`.
+Lint manually with `just lint`, or `just lint-all` to include manual-stage hooks.
 
 ## Running tests
 

--- a/justfile
+++ b/justfile
@@ -66,21 +66,19 @@ typing:
     poetry sync --only main,typing
     poetry run mypy . --install-types --non-interactive
 
-# Run linter
-lint:
-    just pre-commit ruff-format
-    just pre-commit ruff-check
-    just pre-commit validate-pyproject
-    just pre-commit poetry-check
+# Run all pre-commit hooks
+lint *args="":
+    poetry sync --only main,dev
+    poetry run pre-commit run --all-files {{args}}
 
 # Run example notebooks (excludes Calysto Processing and SAS)
 run-notebooks:
     bash scripts/run_notebooks.sh
 
-# Run pre-commit hook
-pre-commit *args="":
+# Run all pre-commit hooks, including manual-stage hooks
+lint-all *args="":
     poetry sync --only main,dev
-    poetry run pre-commit run --all-files {{args}}
+    poetry run pre-commit run --all-files --hook-stage manual {{args}}
 
 # Launch Jupyter console with MetaKernel Python for manual smoke testing
 test-manual:


### PR DESCRIPTION
## References

None

## Description

The five developer commands now mean the same thing in every Calysto repo: `install`, `test`, `cover`, `typing`, and `lint`.

Two things were confusing before. `lint` ran a hand-picked subset of pre-commit hooks while a separate `pre-commit` recipe ran all of them, so neither name described what it did. The lint recipes also did not control their own environment. Because `just test` syncs to the test group and prunes everything else, running it before `just lint` left no pre-commit in the environment. Each recipe now syncs the groups it needs, so any order of commands works.

## Changes

- Renamed the run-all-hooks recipe from `pre-commit` to `lint`
- Added `lint-all` for hooks that only run at the manual stage, such as `markdown-link-check`
- The lint recipes now sync the dev group before running, matching what the other recipes already did
- Updated the contributing guide to match

## Backwards-incompatible changes

`just pre-commit` no longer exists. Use `just lint`, or `just lint-all` to include the manual-stage hooks.

## Testing

- `just lint` passes
- `just typing` passes with no issues in 113 source files
- `just test` passes, 489 tests with 68 skipped

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
