### PR TITLE
Fix two child-process leaks in REPLWrapper

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -336,6 +336,28 @@ class REPLWrapper:
         except Exception as e:
             if e.errno != errno.EACCES:
                 raise
+        finally:
+            self._close_pipes()
+
+    def _close_pipes(self) -> None:
+        """Close the pipes of a PopenSpawn child.
+
+        pexpect's pty spawn closes its descriptor in ``close()``, but PopenSpawn
+        (used wherever there is no pty) has no ``close()`` at all, so its three
+        pipes stay open until the garbage collector finalises them and reports
+        each one as a ResourceWarning.  Wait for the process to go first: the
+        reader thread is blocked on stdout, and letting it see EOF avoids
+        closing the descriptor out from under it.
+        """
+        proc = getattr(self.child, "proc", None)
+        if proc is None:
+            return
+        with contextlib.suppress(Exception):
+            proc.wait(timeout=5)
+        for pipe in (proc.stdin, proc.stdout, proc.stderr):
+            if pipe is not None:
+                with contextlib.suppress(Exception):
+                    pipe.close()
 
 
 def python(command: str = "python") -> REPLWrapper:

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import contextlib
 import errno
 import os
 import signal
@@ -77,35 +78,63 @@ class REPLWrapper:
                 encoding=encoding,
                 env=env,
             )
+            spawned_here = True
         else:
             self.child = cmd_or_spawn
-
-        if self.child.echo and not echo:
-            # Existing spawn instance has echo enabled, disable it
-            # to prevent our input from being repeated to output.
-            self.child.setecho(False)
-            self.child.waitnoecho()
+            spawned_here = False
 
         self.echo = echo
         self.prompt_emit_cmd = prompt_emit_cmd
         self._force_prompt_on_continuation = force_prompt_on_continuation
         self.prompt_change_cmd: str | None = None
-        self.prompt_regex: str | None = None
-
-        if prompt_change_cmd is None:
-            self.prompt_regex = prompt_regex
-        else:
-            formatted_prompt_change_cmd = prompt_change_cmd.format(
-                new_prompt_regex, continuation_prompt_regex
-            )
-            self.set_prompt(prompt_regex, formatted_prompt_change_cmd)
-            self.prompt_regex = new_prompt_regex
+        self.prompt_regex: str | None = prompt_regex
         self.continuation_prompt_regex = continuation_prompt_regex
         self.stdin_prompt_regex = stdin_prompt_regex
 
         self._stream_handler: Any = None
         self._stdin_handler: Any = None
         self._line_handler: Any = None
+
+        try:
+            self._start_child(
+                prompt_regex, prompt_change_cmd, new_prompt_regex, extra_init_cmd
+            )
+        except BaseException:
+            # Startup failed, so __init__ never returns and nothing outside
+            # this frame can reach self.child.  A child spawned here would
+            # keep running for the life of the interpreter, unreferenced and
+            # unkillable, so end it now.  A spawn handed in by the caller
+            # stays theirs to clean up.
+            if spawned_here:
+                with contextlib.suppress(Exception):
+                    self.terminate()
+            raise
+
+    def _start_child(
+        self,
+        prompt_regex: Any,
+        prompt_change_cmd: str | None,
+        new_prompt_regex: Any,
+        extra_init_cmd: str | None,
+    ) -> None:
+        """Settle the child's echo, install the prompt, and wait for it.
+
+        Everything here talks to the child and can fail, which is why it is
+        separate from ``__init__``: the caller can then clean the child up
+        while it is still reachable.
+        """
+        if self.child.echo and not self.echo:
+            # Existing spawn instance has echo enabled, disable it
+            # to prevent our input from being repeated to output.
+            self.child.setecho(False)
+            self.child.waitnoecho()
+
+        if prompt_change_cmd is not None:
+            formatted_prompt_change_cmd = prompt_change_cmd.format(
+                new_prompt_regex, self.continuation_prompt_regex
+            )
+            self.set_prompt(prompt_regex, formatted_prompt_change_cmd)
+            self.prompt_regex = new_prompt_regex
 
         self._expect_prompt()
 

--- a/tests/test_replwrap.py
+++ b/tests/test_replwrap.py
@@ -3,6 +3,8 @@ import platform
 import re
 import sys
 import unittest
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -70,6 +72,34 @@ class REPLWrapTestCase(unittest.TestCase):
         # Check that the REPL was reset (SIGINT) after the incomplete input
         res = bash.run_command("echo '1 2\n3 4'")
         self.assertEqual(res.strip().splitlines(), ["1 2", "3 4"])
+
+    def test_startup_failure_kills_spawned_child(self) -> None:
+        """A child that never sends a prompt is killed rather than leaked.
+
+        __init__ raises before returning, so the caller never gets a wrapper to
+        clean up with; without cleanup here the process outlives the caller.
+        """
+        spawned = []
+        real_spawnu = pexpect.spawnu
+
+        def _spawn_with_short_timeout(*args: Any, **kwargs: Any) -> Any:
+            child = real_spawnu(*args, **kwargs)
+            child.timeout = 2
+            spawned.append(child)
+            return child
+
+        with (
+            patch.object(pexpect, "spawnu", _spawn_with_short_timeout),
+            pytest.raises(pexpect.TIMEOUT),
+        ):
+            replwrap.REPLWrapper(
+                f"{sys.executable} -c 'import time; time.sleep(60)'",
+                "prompt-this-child-never-sends",
+                "PS1='{0}' PS2='{1}'",
+            )
+
+        assert spawned, "the command should have been spawned"
+        assert not spawned[0].isalive(), "the spawned child was left running"
 
     def test_existing_spawn(self) -> None:
         child = pexpect.spawnu("bash", timeout=5, echo=False)

--- a/tests/test_replwrap_init.py
+++ b/tests/test_replwrap_init.py
@@ -141,6 +141,56 @@ class TestREPLWrapperInit:
         mock_run.assert_not_called()
 
 
+class TestStartupFailure:
+    """A failed handshake must not leave the spawned child running.
+
+    __init__ does not return, so the caller never receives the wrapper and has
+    no way to reach ``self.child`` and clean it up.
+    """
+
+    def test_spawned_child_is_terminated(self) -> None:
+        """A child spawned here is terminated when startup fails."""
+        mock_child = _make_child(echo=False)
+        timeout = mk_pexpect.TIMEOUT("no prompt")
+        with (
+            patch("metakernel.pexpect.spawnu", return_value=mock_child),
+            patch.object(REPLWrapper, "_expect_prompt", side_effect=timeout),
+            patch.object(REPLWrapper, "terminate") as mock_terminate,
+            patch("atexit.register"),
+            pytest.raises(mk_pexpect.TIMEOUT),
+        ):
+            REPLWrapper("bash", r"[$#]", None)
+        mock_terminate.assert_called_once_with()
+
+    def test_caller_supplied_spawn_is_left_alone(self) -> None:
+        """A spawn passed in by the caller stays the caller's to clean up."""
+        mock_child = _make_child(echo=False)
+        timeout = mk_pexpect.TIMEOUT("no prompt")
+        with (
+            patch.object(REPLWrapper, "_expect_prompt", side_effect=timeout),
+            patch.object(REPLWrapper, "terminate") as mock_terminate,
+            patch("atexit.register"),
+            pytest.raises(mk_pexpect.TIMEOUT),
+        ):
+            REPLWrapper(mock_child, r"[$#]", None)
+        mock_terminate.assert_not_called()
+
+    def test_terminate_failure_does_not_mask_the_original_error(self) -> None:
+        """The startup error propagates even when the cleanup itself fails."""
+        mock_child = _make_child(echo=False)
+        timeout = mk_pexpect.TIMEOUT("no prompt")
+        with (
+            patch("metakernel.pexpect.spawnu", return_value=mock_child),
+            patch.object(REPLWrapper, "_expect_prompt", side_effect=timeout),
+            patch.object(
+                REPLWrapper, "terminate", side_effect=OSError("cannot signal")
+            ),
+            patch("atexit.register"),
+            pytest.raises(mk_pexpect.TIMEOUT, match="no prompt"),
+        ):
+            REPLWrapper("bash", r"[$#]", None)
+
+
 def _make_wrapper(**kwargs: Any) -> REPLWrapper:
     """Create a REPLWrapper with a mock child, bypassing real subprocess spawning."""
     mock_child = _make_child()

--- a/tests/test_replwrap_init.py
+++ b/tests/test_replwrap_init.py
@@ -575,3 +575,47 @@ class TestTerminate:
         wrapper.child.kill.side_effect = OSError(errno.EPERM, "Operation not permitted")
         with patch.object(mk_pexpect, "pty", None), pytest.raises(OSError):
             wrapper.terminate()
+
+    def test_pty_none_closes_child_pipes(self) -> None:
+        """PopenSpawn has no close(), so terminate() closes its pipes itself."""
+        wrapper = _make_wrapper()
+        proc = MagicMock()
+        wrapper.child.proc = proc
+        with patch.object(mk_pexpect, "pty", None):
+            wrapper.terminate()
+        proc.wait.assert_called_once_with(timeout=5)
+        proc.stdin.close.assert_called_once()
+        proc.stdout.close.assert_called_once()
+        proc.stderr.close.assert_called_once()
+
+    def test_pty_none_closes_pipes_even_when_kill_fails(self) -> None:
+        """A kill that raises must not leave the pipes open."""
+        wrapper = _make_wrapper()
+        proc = MagicMock()
+        wrapper.child.proc = proc
+        wrapper.child.kill.side_effect = OSError(errno.EPERM, "Operation not permitted")
+        with patch.object(mk_pexpect, "pty", None), pytest.raises(OSError):
+            wrapper.terminate()
+        proc.stdout.close.assert_called_once()
+
+    def test_pty_none_survives_a_pipe_that_will_not_close(self) -> None:
+        """One pipe failing to close does not prevent the others from closing."""
+        wrapper = _make_wrapper()
+        proc = MagicMock()
+        proc.stdin.close.side_effect = OSError("already closed")
+        wrapper.child.proc = proc
+        with patch.object(mk_pexpect, "pty", None):
+            wrapper.terminate()  # must not raise
+        proc.stdout.close.assert_called_once()
+        proc.stderr.close.assert_called_once()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="pexpect.pty not available on Windows"
+    )
+    def test_pty_spawn_pipes_are_left_to_pexpect(self) -> None:
+        """A pty spawn closes its own descriptor in close(); nothing to do here."""
+        wrapper = _make_wrapper()
+        proc = MagicMock()
+        wrapper.child.proc = proc
+        wrapper.terminate()
+        proc.stdout.close.assert_not_called()


### PR DESCRIPTION
## References

No issue filed. Found while diagnosing an oct2py CI failure on a Windows runner: https://github.com/blink1073/oct2py/actions/runs/31916428695

## Description

`REPLWrapper.__init__` spawns the child but registers its `atexit` cleanup only once the prompt handshake succeeds. When anything in between raises, `__init__` never returns, so the caller has no wrapper and nothing can reach `self.child`: the process then runs unreferenced for the life of the interpreter. Downstream that showed up as three concurrent Octave startups on a cold Windows runner, one of which passed pexpect's 30s wait for the first prompt and left an orphaned `octave`/`octave-gui` pair behind.

`terminate()` leaked as well, on the `PopenSpawn` path. pexpect's pty spawn closes its descriptor in `close()`, but `PopenSpawn` has no `close()` at all, so all three pipes stayed open until the garbage collector finalised them.

## Changes

- The prompt handshake moves into a private `_start_child()`, so a failure can be caught while the child is still reachable.
- A child spawned by `REPLWrapper` is terminated when startup fails. A spawn passed in by the caller is left alone, and the original error propagates either way.
- Terminating a `PopenSpawn` child closes its pipes, after waiting for the signalled process so the reader thread sees EOF rather than a descriptor closing underneath it.

## Backwards-incompatible changes

None

## Testing

`just test` (496 passed, 69 skipped), `just lint` and `just typing`, all clean. Eight new tests, four of which fail without these changes.

Also verified against real processes on macOS, since the integration test in `test_replwrap.py` only runs in Linux CI: without the startup fix the spawned child is still in the process table after the failure and with it the pid is gone; terminating without closing pipes produced two `ResourceWarning`s at garbage collection, and zero with the fix.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
