### PR TITLE
Publish to PyPI on real releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,9 @@ jobs:
         path: dist
 
     - name: Upload package to PyPI
-      if: ${{ !needs.release.outputs.dry_run }}
+      # Job outputs are strings, so "!dry_run" is always false here: the
+      # string "false" is truthy. Compare against "true" instead.
+      if: ${{ needs.release.outputs.dry_run != 'true' }}
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         attestations: false


### PR DESCRIPTION
## References

No issue filed. Noticed while checking whether the 1.0.5 release carried #475.

## Description

Nothing has reached PyPI since 1.0.0. Releases 1.0.1 through 1.0.5 all have tags and GitHub releases, and every `publish` job reported success, but the upload step inside it was skipped every time:

```
publish: success
  ✓ Download packages built by build-and-inspect-python-package
  ⊘ Upload package to PyPI
  ✓ Complete job
```

The step is gated on `if: ${{ !needs.release.outputs.dry_run }}`. Job outputs are always strings, so on a real release that output is the string `"false"`, which is truthy, making `!"false"` false and skipping the upload. The only value that would ever run it is an empty string. Because the skip is not a failure, the job stays green and the missing upload goes unnoticed.

`octave_kernel` already uses the string comparison this changes to, and `oct2py` avoids the problem by testing `inputs.dry_run` directly, where it is a real boolean.

## Changes

- The PyPI upload step now tests `needs.release.outputs.dry_run != 'true'`, so real releases publish and dry runs and the nightly scheduled run still do not.
- Added a comment on the condition so it does not get "simplified" back to a bare negation.

## Backwards-incompatible changes

None

## Testing

`actionlint` passes and the workflow parses. The condition itself cannot be exercised without running a release: with `dry_run: false` the expression now evaluates `"false" != 'true'` to true, and for the scheduled run and explicit dry runs the output is `"true"`, so it stays false.

Note that 1.0.5 is tagged but was never published, so it will need a roll forward to 1.0.6 after this merges.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
