### PR TITLE
Fix intermittent Windows CI failure from PowerShell prompt desync

### DIFF
--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -407,7 +407,17 @@ def bash(command: str = "bash", prompt_regex: str = "[$#]") -> REPLWrapper:
 
 def powershell(command: str = "powershell", prompt_regex: str = ">") -> REPLWrapper:
     """ "Start a powershell and return a :class:`REPLWrapper` object."""
-    return REPLWrapper(command, prompt_regex, 'Function prompt {{ "{0}" }}', echo=True)
+    # PowerShell echoes back every line it is sent. A prompt-setting command
+    # that spelled the prompt out in full would arrive on the output stream
+    # ahead of the prompt it installs, and be matched in its place: from then
+    # on every read would be one prompt behind, so each command would return
+    # the previous command's output and the last one would be lost. Build the
+    # prompt from two halves so the echoed command cannot contain it, the way
+    # bash() hides "\\[\\]" inside PS1 for the same reason.
+    prompt = f'"{PEXPECT_PROMPT[:5]}" + "{PEXPECT_PROMPT[5:]}"'
+    return REPLWrapper(
+        command, prompt_regex, "Function prompt {{ " + prompt + " }}", echo=True
+    )
 
 
 def strip_bracketing(

--- a/metakernel/replwrap.py
+++ b/metakernel/replwrap.py
@@ -407,13 +407,9 @@ def bash(command: str = "bash", prompt_regex: str = "[$#]") -> REPLWrapper:
 
 def powershell(command: str = "powershell", prompt_regex: str = ">") -> REPLWrapper:
     """ "Start a powershell and return a :class:`REPLWrapper` object."""
-    # PowerShell echoes back every line it is sent. A prompt-setting command
-    # that spelled the prompt out in full would arrive on the output stream
-    # ahead of the prompt it installs, and be matched in its place: from then
-    # on every read would be one prompt behind, so each command would return
-    # the previous command's output and the last one would be lost. Build the
-    # prompt from two halves so the echoed command cannot contain it, the way
-    # bash() hides "\\[\\]" inside PS1 for the same reason.
+    # PowerShell echoes each line it is sent, so a command spelling the prompt
+    # out in full gets matched in place of the prompt it installs, leaving every
+    # later read one prompt behind. Split it, as bash() does with "\\[\\]" in PS1.
     prompt = f'"{PEXPECT_PROMPT[:5]}" + "{PEXPECT_PROMPT[5:]}"'
     return REPLWrapper(
         command, prompt_regex, "Function prompt {{ " + prompt + " }}", echo=True

--- a/tests/test_replwrap_powershell.py
+++ b/tests/test_replwrap_powershell.py
@@ -1,0 +1,131 @@
+"""Tests for the PowerShell prompt handshake in :func:`metakernel.replwrap.powershell`.
+
+These drive a scripted stand-in for the child process, so they exercise the
+Windows code path on every platform.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from metakernel import pexpect, replwrap
+from metakernel.pexpect import TIMEOUT
+from metakernel.replwrap import PEXPECT_PROMPT
+
+BANNER_HEAD = "Windows PowerShell\r\n"
+# The rest of the banner, ending in PowerShell's own first prompt.  It arrives
+# only once the first line has been sent, which is what makes the handshake
+# racy against a real shell.
+BANNER_TAIL = (
+    "Copyright (C) Microsoft Corporation. All rights reserved.\r\n\r\nPS C:\\> "
+)
+
+LS_COMMAND = "ls C:/Users/RUNNER~1/AppData/Local/Temp/tmp_pmy5t3z"
+LS_OUTPUT = (
+    "\r\n    Directory: C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\r\n\r\n"
+    "Mode                 LastWriteTime         Length Name\r\n"
+    "----                 -------------   ------------ ----\r\n"
+    "-a---           8/17/2026 10:04 AM              0 tmp_pmy5t3z\r\n\r\n"
+)
+
+
+class FakePowerShell:
+    """A scripted stand-in for a PowerShell child process.
+
+    PowerShell echoes each line it is sent, then writes that command's output
+    followed by the next prompt.  ``Function prompt`` lines are interpreted the
+    way PowerShell would: the double-quoted pieces are concatenated and become
+    the prompt from then on.
+    """
+
+    crlf = "\r\n"
+
+    def __init__(self, outputs: dict[str, str] | None = None) -> None:
+        self.buffer = BANNER_HEAD
+        self.pending = [BANNER_TAIL]
+        self.outputs = outputs or {}
+        self.prompt = "PS C:\\> "
+        self.echo = True
+        self.before = ""
+        self.after = ""
+        self.sent: list[str] = []
+
+    def expect(self, patterns: Any, timeout: Any = None) -> int:
+        if not isinstance(patterns, list):
+            patterns = [patterns]
+        best_index = None
+        best_match = None
+        for index, pattern in enumerate(patterns):
+            if pattern is None:
+                continue
+            match = re.search(pattern, self.buffer)
+            if match is None:
+                continue
+            if best_match is None or match.start() < best_match.start():
+                best_index, best_match = index, match
+        if best_match is None or best_index is None:
+            raise TIMEOUT("no match in buffer")
+        self.before = self.buffer[: best_match.start()]
+        self.after = best_match.group()
+        self.buffer = self.buffer[best_match.end() :]
+        return best_index
+
+    def readline(self) -> str:
+        index = self.buffer.find(self.crlf)
+        if index == -1:
+            raise TIMEOUT("no complete line in buffer")
+        line = self.buffer[: index + len(self.crlf)]
+        self.buffer = self.buffer[index + len(self.crlf) :]
+        return line
+
+    def sendline(self, line: str) -> None:
+        self.sent.append(line)
+        if self.pending:
+            self.buffer += self.pending.pop(0)
+        self.buffer += line + self.crlf
+        if line.startswith("Function prompt"):
+            self.prompt = "".join(re.findall(r'"([^"]*)"', line))
+        else:
+            self.buffer += self.outputs.get(line, "")
+        self.buffer += self.prompt
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def kill(self, sig: int) -> None:
+        pass
+
+
+@pytest.fixture
+def repl(monkeypatch: pytest.MonkeyPatch) -> replwrap.REPLWrapper:
+    child = FakePowerShell(outputs={LS_COMMAND: LS_OUTPUT})
+    monkeypatch.setattr(pexpect, "spawnu", lambda *a, **kw: child)
+    return replwrap.powershell()
+
+
+def test_prompt_change_cmd_does_not_spell_out_the_prompt(
+    repl: replwrap.REPLWrapper,
+) -> None:
+    """The command that installs the prompt must not contain the prompt.
+
+    PowerShell echoes it back, and an echo containing the prompt is
+    indistinguishable from the prompt itself.
+    """
+    assert repl.prompt_change_cmd is not None
+    assert PEXPECT_PROMPT not in repl.prompt_change_cmd
+
+
+def test_command_output_survives_the_prompt_handshake(
+    repl: replwrap.REPLWrapper,
+) -> None:
+    """Output must not be dropped by a wrapper left one prompt behind."""
+    streamed: list[str] = []
+    repl.run_command('cd "C:/work"')
+    repl.run_command(LS_COMMAND, stream_handler=streamed.append)
+    assert "tmp_pmy5t3z" in "".join(streamed)

--- a/tests/test_replwrap_powershell.py
+++ b/tests/test_replwrap_powershell.py
@@ -1,7 +1,6 @@
-"""Tests for the PowerShell prompt handshake in :func:`metakernel.replwrap.powershell`.
+"""Tests for the PowerShell prompt handshake.
 
-These drive a scripted stand-in for the child process, so they exercise the
-Windows code path on every platform.
+A scripted stand-in for the child process runs the Windows path everywhere.
 """
 
 from __future__ import annotations
@@ -16,9 +15,7 @@ from metakernel.pexpect import TIMEOUT
 from metakernel.replwrap import PEXPECT_PROMPT
 
 BANNER_HEAD = "Windows PowerShell\r\n"
-# The rest of the banner, ending in PowerShell's own first prompt.  It arrives
-# only once the first line has been sent, which is what makes the handshake
-# racy against a real shell.
+# Arrives only after the first line is sent, which is what makes this racy.
 BANNER_TAIL = (
     "Copyright (C) Microsoft Corporation. All rights reserved.\r\n\r\nPS C:\\> "
 )
@@ -35,10 +32,9 @@ LS_OUTPUT = (
 class FakePowerShell:
     """A scripted stand-in for a PowerShell child process.
 
-    PowerShell echoes each line it is sent, then writes that command's output
-    followed by the next prompt.  ``Function prompt`` lines are interpreted the
-    way PowerShell would: the double-quoted pieces are concatenated and become
-    the prompt from then on.
+    Each line sent is echoed back, then that command's output, then the prompt.
+    A ``Function prompt`` line installs the concatenation of its quoted pieces
+    as the new prompt, the way PowerShell would.
     """
 
     crlf = "\r\n"
@@ -112,11 +108,7 @@ def repl(monkeypatch: pytest.MonkeyPatch) -> replwrap.REPLWrapper:
 def test_prompt_change_cmd_does_not_spell_out_the_prompt(
     repl: replwrap.REPLWrapper,
 ) -> None:
-    """The command that installs the prompt must not contain the prompt.
-
-    PowerShell echoes it back, and an echo containing the prompt is
-    indistinguishable from the prompt itself.
-    """
+    """An echo carrying the prompt is indistinguishable from the prompt."""
     assert repl.prompt_change_cmd is not None
     assert PEXPECT_PROMPT not in repl.prompt_change_cmd
 


### PR DESCRIPTION
## References

Fixes the intermittent `Cover (windows-latest)` failure seen in
https://github.com/Calysto/metakernel/actions/runs/32018097304/job/95351781566

## Description

`powershell()` installed its prompt by sending
`Function prompt { "PEXPECT_PROMPT>" }`. PowerShell echoes every line it is
sent, so that command came back carrying the prompt sentinel and
`_expect_prompt` matched the echo rather than the prompt it installs. The
wrapper then ran one prompt behind for the life of the shell: each command
returned the previous command's output, and the last one was dropped.

The echo is normally swallowed by the `readline()` in `sendline()`. When
PowerShell's startup banner arrives in more than one piece, that `readline()`
eats a banner line instead and the shell stays desynchronized, which is why CI
fails only every few runs. Recent casualties are `test_magics`
(`assert 'tmp_pmy5t3z' in ''`) and `test_shell_magic3`.

Building the prompt from two concatenated halves closes the window. `bash()`
already avoids the same trap by hiding `\[\]` inside `PS1`.

## Changes

- The PowerShell REPL wrapper no longer loses command output after a slow shell
  startup.
- Added tests for the PowerShell prompt handshake, driven by a scripted stand-in
  for the child process so the Windows path runs on every platform.

## Backwards-incompatible changes

None

## Testing

`tests/test_replwrap_powershell.py` reproduces the CI failure on macOS: against
the unfixed code it fails with `assert 'tmp_pmy5t3z' in ''`, matching the
Windows job, and passes with the fix.

- `just test`: 498 passed, 69 skipped
- `just typing`: no issues found in 114 source files
- `just lint`: passed

The fix cannot be exercised against a real PowerShell locally, so confirmation
depends on this PR's own CI. One green Windows run is weak evidence for a
failure that hits roughly 2 runs in 15.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
